### PR TITLE
FRONTEND-1737 Update to support 301 for trailing slashes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,7 +48,6 @@ module.exports = function(grunt) {
       options: {
         accessKeyId: '<%= aws.key %>',
         secretAccessKey: '<%= aws.secret %>',
-        sessionToken: '<%= aws.session %>',
         bucket: 'demos.algorithmia.com',
         region: 'us-east-1',
         uploadConcurrency: 5,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,8 +16,7 @@ module.exports = function(grunt) {
     { slug: 'autotag', dist: 'JavaScript/autotag' },
     { slug: 'analyze-tweets', dist: 'JavaScript/analyze-tweets'},
     { slug: 'classify-places', dist: 'JavaScript/places-demo'},
-    { slug: 'colorize-photos', dist: 'JavaScript/colorization-demo' },
-    { slug: 'cluster', dist: 'Javascript/cluster' },
+    { slug: 'cluster', dist: 'JavaScript/cluster' },
     { slug: 'colorize-photos', dist: 'JavaScript/colorization-demo' },
     { slug: 'doc-classifier', dist: 'JavaScript/doc-classifier'},
     { slug: 'deep-fashion', dist: 'JavaScript/deep-fashion'},
@@ -49,7 +48,8 @@ module.exports = function(grunt) {
       options: {
         accessKeyId: '<%= aws.key %>',
         secretAccessKey: '<%= aws.secret %>',
-        bucket: 'algorithmia-synapse',
+        sessionToken: '<%= aws.session %>',
+        bucket: 'demos.algorithmia.com',
         region: 'us-east-1',
         uploadConcurrency: 5,
         differential: true,
@@ -165,7 +165,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     aws: grunt.file.readJSON('aws-keys.json'),
     aws_s3: awsS3Config,
-    // cloudfront_invalidate: cloudfrontConfig,
+    cloudfront_invalidate: cloudfrontConfig,
     clean: cleanConfig,
     copy: copyConfig,
     template: templateConfig,
@@ -173,7 +173,7 @@ module.exports = function(grunt) {
   });
 
   grunt.loadNpmTasks('grunt-aws-s3');
-  // grunt.loadNpmTasks('grunt-cloudfront-invalidate');
+  grunt.loadNpmTasks('grunt-cloudfront-invalidate');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-watch');
@@ -188,7 +188,7 @@ module.exports = function(grunt) {
         "copy:" + demo.slug,
         "template:" + demo.slug,
         "aws_s3:" + demo.slug,
-        // "cloudfront_invalidate:" + demo.slug
+        "cloudfront_invalidate:" + demo.slug
       ]
     );
     grunt.registerTask(

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,7 +49,7 @@ module.exports = function(grunt) {
       options: {
         accessKeyId: '<%= aws.key %>',
         secretAccessKey: '<%= aws.secret %>',
-        bucket: 'demos.algorithmia.com',
+        bucket: 'algorithmia-synapse',
         region: 'us-east-1',
         uploadConcurrency: 5,
         differential: true,
@@ -73,19 +73,47 @@ module.exports = function(grunt) {
     }
   };
 
-  var dateString = new Date().getTime();
-  var getTemplate = function(template) {
-    return grunt.file.read(template).split('[[VERSION]]').join(dateString);
-  };
+  const getTemplate = (template, slug) =>
+    grunt.file
+      .read(template)
+      .replace(new RegExp("<%= demo_root %>", "g"), slug)
+      .split("[[VERSION]]")
+      .join(new Date().getTime());
+
+  const isIndexHTML = filepath => /index\.html$/.test(filepath);
 
   demos.forEach(function(demo) {
+    const file = {
+      expand: true,
+      cwd: "build/" + demo.slug,
+      src: ["**"],
+      dest: demo.slug,
+      filter: filepath => !isIndexHTML(filepath)
+    };
+
     awsS3Config[demo.slug] = {
-      files: [{
-        expand: true,
-        cwd: 'build/'+demo.slug,
-        src: ['**'],
-        dest: demo.slug
-      }]
+      files: [
+        // Non index.html files are uploaded to S3 directly.
+        file,
+        // index.html files are given metadata value to enable 301 redirect
+        // e.g., site.com/foo/index.html and site.com/foo/ will both redirect
+        // to site.com/foo
+        {
+          ...file,
+          filter: isIndexHTML,
+          params: {
+            WebsiteRedirectLocation: `/${demo.slug}`
+          }
+        },
+        // Upload the equivalent of index.html, but without an extension and
+        // renamed to the demo.slug value so that the 301 doesn't 404.
+        {
+          ...file,
+          filter: isIndexHTML,
+          dest: "/",
+          rename: () => demo.slug
+        }
+      ]
     };
     cleanConfig[demo.slug] = ['build/'+demo.slug];
     copyConfig[demo.slug] = {
@@ -108,11 +136,12 @@ module.exports = function(grunt) {
     templateConfig[demo.slug] = {
       options: {
         data: {
-          header_begin: getTemplate('JavaScript/common/header_begin.html'),
-          header_end: getTemplate('JavaScript/common/header_end.html'),
-          footer: getTemplate('JavaScript/common/footer.html'),
-          ga_script: getTemplate('JavaScript/common/ga_script.html'),
-          segment_script: getTemplate('JavaScript/common/segment_script.html')
+          demo_root: demo.slug,
+          header_begin: getTemplate('JavaScript/common/header_begin.html', demo.slug),
+          header_end: getTemplate('JavaScript/common/header_end.html', demo.slug),
+          footer: getTemplate('JavaScript/common/footer.html', demo.slug),
+          ga_script: getTemplate('JavaScript/common/ga_script.html', demo.slug),
+          segment_script: getTemplate('JavaScript/common/segment_script.html', demo.slug)
         }
       },
       files: [
@@ -136,7 +165,7 @@ module.exports = function(grunt) {
   grunt.initConfig({
     aws: grunt.file.readJSON('aws-keys.json'),
     aws_s3: awsS3Config,
-    cloudfront_invalidate: cloudfrontConfig,
+    // cloudfront_invalidate: cloudfrontConfig,
     clean: cleanConfig,
     copy: copyConfig,
     template: templateConfig,
@@ -144,15 +173,29 @@ module.exports = function(grunt) {
   });
 
   grunt.loadNpmTasks('grunt-aws-s3');
-  grunt.loadNpmTasks('grunt-cloudfront-invalidate');
+  // grunt.loadNpmTasks('grunt-cloudfront-invalidate');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-template');
 
   demos.forEach(function(demo) {
-    grunt.registerTask('publish:' + demo.slug, "Publish the " + demo.slug + " demo", ['clean:' + demo.slug, 'copy:' + demo.slug, 'template:' + demo.slug, 'aws_s3:' + demo.slug, 'cloudfront_invalidate:' + demo.slug]);
-    grunt.registerTask('build:' + demo.slug, "Build the " + demo.slug + " demo", ['clean:' + demo.slug, 'copy:' + demo.slug, 'template:' + demo.slug]);
+    grunt.registerTask(
+      "publish:" + demo.slug,
+      "Publish the " + demo.slug + " demo",
+      [
+        "clean:" + demo.slug,
+        "copy:" + demo.slug,
+        "template:" + demo.slug,
+        "aws_s3:" + demo.slug,
+        // "cloudfront_invalidate:" + demo.slug
+      ]
+    );
+    grunt.registerTask(
+      "build:" + demo.slug,
+      "Build the " + demo.slug + " demo",
+      ["clean:" + demo.slug, "copy:" + demo.slug, "template:" + demo.slug]
+    );
   });
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,7 +76,7 @@ module.exports = function(grunt) {
   const getTemplate = (template, slug) =>
     grunt.file
       .read(template)
-      .replace(new RegExp("<%= demo_root %>", "g"), slug)
+      .replace(new RegExp("<%= slug %>", "g"), slug)
       .split("[[VERSION]]")
       .join(new Date().getTime());
 
@@ -136,7 +136,7 @@ module.exports = function(grunt) {
     templateConfig[demo.slug] = {
       options: {
         data: {
-          demo_root: demo.slug,
+          slug: demo.slug,
           header_begin: getTemplate('JavaScript/common/header_begin.html', demo.slug),
           header_end: getTemplate('JavaScript/common/header_end.html', demo.slug),
           footer: getTemplate('JavaScript/common/footer.html', demo.slug),

--- a/JavaScript/RSS_dashboard/index.html
+++ b/JavaScript/RSS_dashboard/index.html
@@ -4,7 +4,7 @@
 
 <title>RSS Dashboard - Algorithmia</title>
 
-<link rel="canonical" href="https://demos.algorithmia.com/rss-dashboard/">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
 <meta name="description" content="Automatically create summaries, extract tags, and analyze the sentiment of RSS feeds with this microservice.">
 
 <!-- FB -->

--- a/JavaScript/RSS_dashboard/index.html
+++ b/JavaScript/RSS_dashboard/index.html
@@ -4,7 +4,7 @@
 
 <title>RSS Dashboard - Algorithmia</title>
 
-<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>">
 <meta name="description" content="Automatically create summaries, extract tags, and analyze the sentiment of RSS feeds with this microservice.">
 
 <!-- FB -->

--- a/JavaScript/amazon-miner/index.html
+++ b/JavaScript/amazon-miner/index.html
@@ -1,10 +1,10 @@
 <html>
   <head>
 	<title>Amazon Miner - Algorithmia</title>
-	<link rel="stylesheet" href="public/css/reset.css">
+	<link rel="stylesheet" href="<%= demo_root %>/public/css/reset.css">
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Varela+Round">
-	<link rel="stylesheet" href="public/css/main.css">
+	<link rel="stylesheet" href="<%= demo_root %>/public/css/main.css">
 	</head>
   <body>
 
@@ -58,15 +58,15 @@
 		</div>
 	</script>
 
-	<script type="text/javascript" src="public/js/jquery.min.js"></script>
-	<script type="text/javascript" src="public/js/algorithmia.js"></script>
+	<script type="text/javascript" src="<%= demo_root %>/public/js/jquery.min.js"></script>
+	<script type="text/javascript" src="<%= demo_root %>/public/js/algorithmia.js"></script>
 	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.16/d3.min.js"></script>
 	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.1.1/mustache.min.js"></script>
 	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
-	<script type="text/javascript" src="public/js/radarchart.js"></script>
-	<script type="text/javascript" src="public/js/configurator.js"></script>
-	<script type="text/javascript" src="public/js/chartmaker.js"></script>
-	<script type="text/javascript" src="public/js/main.js"></script>
+	<script type="text/javascript" src="<%= demo_root %>/public/js/radarchart.js"></script>
+	<script type="text/javascript" src="<%= demo_root %>/public/js/configurator.js"></script>
+	<script type="text/javascript" src="<%= demo_root %>/public/js/chartmaker.js"></script>
+	<script type="text/javascript" src="<%= demo_root %>/public/js/main.js"></script>
 
   </body>
 </html>

--- a/JavaScript/amazon-miner/index.html
+++ b/JavaScript/amazon-miner/index.html
@@ -1,10 +1,10 @@
 <html>
   <head>
 	<title>Amazon Miner - Algorithmia</title>
-	<link rel="stylesheet" href="<%= demo_root %>/public/css/reset.css">
+	<link rel="stylesheet" href="<%= slug %>/public/css/reset.css">
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Varela+Round">
-	<link rel="stylesheet" href="<%= demo_root %>/public/css/main.css">
+	<link rel="stylesheet" href="<%= slug %>/public/css/main.css">
 	</head>
   <body>
 
@@ -58,15 +58,15 @@
 		</div>
 	</script>
 
-	<script type="text/javascript" src="<%= demo_root %>/public/js/jquery.min.js"></script>
-	<script type="text/javascript" src="<%= demo_root %>/public/js/algorithmia.js"></script>
+	<script type="text/javascript" src="<%= slug %>/public/js/jquery.min.js"></script>
+	<script type="text/javascript" src="<%= slug %>/public/js/algorithmia.js"></script>
 	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.16/d3.min.js"></script>
 	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.1.1/mustache.min.js"></script>
 	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
-	<script type="text/javascript" src="<%= demo_root %>/public/js/radarchart.js"></script>
-	<script type="text/javascript" src="<%= demo_root %>/public/js/configurator.js"></script>
-	<script type="text/javascript" src="<%= demo_root %>/public/js/chartmaker.js"></script>
-	<script type="text/javascript" src="<%= demo_root %>/public/js/main.js"></script>
+	<script type="text/javascript" src="<%= slug %>/public/js/radarchart.js"></script>
+	<script type="text/javascript" src="<%= slug %>/public/js/configurator.js"></script>
+	<script type="text/javascript" src="<%= slug %>/public/js/chartmaker.js"></script>
+	<script type="text/javascript" src="<%= slug %>/public/js/main.js"></script>
 
   </body>
 </html>

--- a/JavaScript/analyze-tweets/index.html
+++ b/JavaScript/analyze-tweets/index.html
@@ -1,12 +1,12 @@
 <html>
  <head>
    <title>Analyze Tweets - Algorithmia</title>
-   <link rel="stylesheet" href="public/css/reset.css">
-   <link rel="stylesheet" href="public/css/font-awesome/css/font-awesome.min.css">
-   <link rel="stylesheet" href="public/css/sweetalert.css">
-   <link rel="stylesheet" href="public/css/bootstrap.min.css">
-   <link rel="stylesheet" href="public/css/jquery.dataTables.min.css">
-   <link rel="stylesheet" href="public/css/style.css">
+   <link rel="stylesheet" href="<%= demo_root %>/public/css/reset.css">
+   <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
+   <link rel="stylesheet" href="<%= demo_root %>/public/css/sweetalert.css">
+   <link rel="stylesheet" href="<%= demo_root %>/public/css/bootstrap.min.css">
+   <link rel="stylesheet" href="<%= demo_root %>/public/css/jquery.dataTables.min.css">
+   <link rel="stylesheet" href="<%= demo_root %>/public/css/style.css">
    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Varela+Round">
 
    <!-- Segment -->
@@ -37,14 +37,14 @@
      </div>
    </div>
 
-   <script src="public/js/jquery.min.js"></script>
-   <script src="public/js/bootstrap.min.js"></script>
-   <script src="public/js/highlight.pack.js"></script>
-   <script src="public/js/algorithmia.js"></script>
-   <script src="public/js/sweetalert.min.js"></script>
-   <script src="public/js/d3.min.js"></script>
-   <script src="public/js/jquery.dataTables.min.js"></script>
-   <script src="public/js/common.js"></script>
-   <script src="public/js/main.js?v=20150530"></script>
+   <script src="<%= demo_root %>/public/js/jquery.min.js"></script>
+   <script src="<%= demo_root %>/public/js/bootstrap.min.js"></script>
+   <script src="<%= demo_root %>/public/js/highlight.pack.js"></script>
+   <script src="<%= demo_root %>/public/js/algorithmia.js"></script>
+   <script src="<%= demo_root %>/public/js/sweetalert.min.js"></script>
+   <script src="<%= demo_root %>/public/js/d3.min.js"></script>
+   <script src="<%= demo_root %>/public/js/jquery.dataTables.min.js"></script>
+   <script src="<%= demo_root %>/public/js/common.js"></script>
+   <script src="<%= demo_root %>/public/js/main.js?v=20150530"></script>
  </body>
 </html>

--- a/JavaScript/analyze-tweets/index.html
+++ b/JavaScript/analyze-tweets/index.html
@@ -1,12 +1,12 @@
 <html>
  <head>
    <title>Analyze Tweets - Algorithmia</title>
-   <link rel="stylesheet" href="<%= demo_root %>/public/css/reset.css">
-   <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
-   <link rel="stylesheet" href="<%= demo_root %>/public/css/sweetalert.css">
-   <link rel="stylesheet" href="<%= demo_root %>/public/css/bootstrap.min.css">
-   <link rel="stylesheet" href="<%= demo_root %>/public/css/jquery.dataTables.min.css">
-   <link rel="stylesheet" href="<%= demo_root %>/public/css/style.css">
+   <link rel="stylesheet" href="<%= slug %>/public/css/reset.css">
+   <link rel="stylesheet" href="<%= slug %>/public/css/font-awesome/css/font-awesome.min.css">
+   <link rel="stylesheet" href="<%= slug %>/public/css/sweetalert.css">
+   <link rel="stylesheet" href="<%= slug %>/public/css/bootstrap.min.css">
+   <link rel="stylesheet" href="<%= slug %>/public/css/jquery.dataTables.min.css">
+   <link rel="stylesheet" href="<%= slug %>/public/css/style.css">
    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Varela+Round">
 
    <!-- Segment -->
@@ -37,14 +37,14 @@
      </div>
    </div>
 
-   <script src="<%= demo_root %>/public/js/jquery.min.js"></script>
-   <script src="<%= demo_root %>/public/js/bootstrap.min.js"></script>
-   <script src="<%= demo_root %>/public/js/highlight.pack.js"></script>
-   <script src="<%= demo_root %>/public/js/algorithmia.js"></script>
-   <script src="<%= demo_root %>/public/js/sweetalert.min.js"></script>
-   <script src="<%= demo_root %>/public/js/d3.min.js"></script>
-   <script src="<%= demo_root %>/public/js/jquery.dataTables.min.js"></script>
-   <script src="<%= demo_root %>/public/js/common.js"></script>
-   <script src="<%= demo_root %>/public/js/main.js?v=20150530"></script>
+   <script src="<%= slug %>/public/js/jquery.min.js"></script>
+   <script src="<%= slug %>/public/js/bootstrap.min.js"></script>
+   <script src="<%= slug %>/public/js/highlight.pack.js"></script>
+   <script src="<%= slug %>/public/js/algorithmia.js"></script>
+   <script src="<%= slug %>/public/js/sweetalert.min.js"></script>
+   <script src="<%= slug %>/public/js/d3.min.js"></script>
+   <script src="<%= slug %>/public/js/jquery.dataTables.min.js"></script>
+   <script src="<%= slug %>/public/js/common.js"></script>
+   <script src="<%= slug %>/public/js/main.js?v=20150530"></script>
  </body>
 </html>

--- a/JavaScript/autotag/index.html
+++ b/JavaScript/autotag/index.html
@@ -2,10 +2,10 @@
   <head>
     <title>Auto-generate Tags - Algorithmia</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,300,400,600,700" rel="stylesheet" type="text/css">
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
-    <link rel="stylesheet" media="screen" href="public/css/bootstrap3.min.css">
-    <link rel="stylesheet" media="screen" href="public/css/algo.min.css">
-    <script src="public/js/algorithmia.js" type="text/javascript"></script>
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/bootstrap3.min.css">
+    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/algo.min.css">
+    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
     <script>
     function run() {
         var e = document.getElementById("urlDD");

--- a/JavaScript/autotag/index.html
+++ b/JavaScript/autotag/index.html
@@ -2,10 +2,10 @@
   <head>
     <title>Auto-generate Tags - Algorithmia</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,300,400,600,700" rel="stylesheet" type="text/css">
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
-    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/bootstrap3.min.css">
-    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/algo.min.css">
-    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="stylesheet" media="screen" href="<%= slug %>/public/css/bootstrap3.min.css">
+    <link rel="stylesheet" media="screen" href="<%= slug %>/public/css/algo.min.css">
+    <script src="<%= slug %>/public/js/algorithmia.js" type="text/javascript"></script>
     <script>
     function run() {
         var e = document.getElementById("urlDD");

--- a/JavaScript/cluster/index.html
+++ b/JavaScript/cluster/index.html
@@ -29,13 +29,13 @@
 
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
 
-  <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
+  <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
 
-  <link rel="stylesheet" href="public/css/font-awesome/css/font-awesome.min.css">
-  <link rel="stylesheet" href="public/css/core.cat.min.css">
+  <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
+  <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
 
   <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
-  <script src="public/js/algorithmia-0.2.0.js"></script>
+  <script src="<%= demo_root %>/public/js/algorithmia-0.2.0.js"></script>
 </head>
 <body>
   <div class="container content-container">
@@ -89,9 +89,9 @@ Algorithmia.client(api_key).algo("/kenny/WekaCluster").pipe([
       height:           500px;
     }
     </style>
-    <script src="public/js/common.cat.js" type="text/javascript"></script>
-    <script src="public/js/d3.v3.min.js" type="text/javascript"></script>
-    <script src="public/js/algorithmia.d3.js" type="text/javascript"></script>
-    <script src="public/js/main.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/d3.v3.min.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
   </div>
 </body>

--- a/JavaScript/cluster/index.html
+++ b/JavaScript/cluster/index.html
@@ -29,13 +29,13 @@
 
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
 
-  <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+  <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
 
-  <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
-  <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
+  <link rel="stylesheet" href="<%= slug %>/public/css/font-awesome/css/font-awesome.min.css">
+  <link rel="stylesheet" href="<%= slug %>/public/css/core.cat.min.css">
 
   <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
-  <script src="<%= demo_root %>/public/js/algorithmia-0.2.0.js"></script>
+  <script src="<%= slug %>/public/js/algorithmia-0.2.0.js"></script>
 </head>
 <body>
   <div class="container content-container">
@@ -89,9 +89,9 @@ Algorithmia.client(api_key).algo("/kenny/WekaCluster").pipe([
       height:           500px;
     }
     </style>
-    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/d3.v3.min.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/d3.v3.min.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/main.js" type="text/javascript"></script>
   </div>
 </body>

--- a/JavaScript/colorization-demo/index.html
+++ b/JavaScript/colorization-demo/index.html
@@ -3,17 +3,17 @@
 	<%= ga_script %>
 
 	<title>Colorize Black and White Photos – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>" />
 	<meta name="description" content="Automatically colorize black and white photos, pictures, and images using the Colorful Image Colorization microservice.">
 	<meta name="robots" content="index,follow">
 
 	<!-- FB -->
 	<meta property="og:title" content="Colorize Black and White Photos">
-	<meta property="og:url" content="https://demos.algorithmia.com/<%= demo_root %>">
+	<meta property="og:url" content="https://demos.algorithmia.com/<%= slug %>">
 	<meta property="og:description" content="Automatically colorize black and white photos, pictures, and images using the Colorful Image Colorization microservice">
 	<meta property="og:locale" content="en_US" />
 	<meta property="og:type" content="website" />
-	<meta property="og:image" content="<%= demo_root %>/public/images/fbshare.png" />
+	<meta property="og:image" content="<%= slug %>/public/images/fbshare.png" />
 	<meta property="og:site_name" content="Algorithmia" />
 
 	<!-- TWTR -->
@@ -21,7 +21,7 @@
 	<meta name="twitter:site" content="@algorithmia" />
 	<meta name="twitter:title" content="Colorize Black and White Photos" />
 	<meta name="twitter:description" content="Automatically colorize black and white photos, pictures, and images using the Colorful Image Colorization microservice" />
-	<meta name="twitter:image" content="<%= demo_root %>/public/images/twshare.png" />
+	<meta name="twitter:image" content="<%= slug %>/public/images/twshare.png" />
 	<meta name="twitter:creator" content="@algorithmia" />
 
 	<!-- OTHER -->
@@ -52,19 +52,19 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/e/ef/Ocean_beach_at_low_tide_against_the_sun.jpg')"><img src="<%= demo_root %>/public/images/water.png"></a>
+								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/e/ef/Ocean_beach_at_low_tide_against_the_sun.jpg')"><img src="<%= slug %>/public/images/water.png"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/c/ce/MaynardYingst_SprintCar.jpg')"><img src="<%= demo_root %>/public/images/car.png" class="sample-image"></a>
+								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/c/ce/MaynardYingst_SprintCar.jpg')"><img src="<%= slug %>/public/images/car.png" class="sample-image"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/7/7d/Yosemite_(14359652100).jpg')"><img src="<%= demo_root %>/public/images/yosemite.png" class="sample-image"></a>
+								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/7/7d/Yosemite_(14359652100).jpg')"><img src="<%= slug %>/public/images/yosemite.png" class="sample-image"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/e/e5/Fire-breather_CIELAB_L*.jpg')"><img src="<%= demo_root %>/public/images/fire.png" class="sample-image"></a>
+								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/e/e5/Fire-breather_CIELAB_L*.jpg')"><img src="<%= slug %>/public/images/fire.png" class="sample-image"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/4/4d/Beef_Portrait_(5210343960).jpg')"><img src="<%= demo_root %>/public/images/cows.png" class="sample-image"></a>
+								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/4/4d/Beef_Portrait_(5210343960).jpg')"><img src="<%= slug %>/public/images/cows.png" class="sample-image"></a>
 							</div>
 						</div>
 					</div>
@@ -151,9 +151,9 @@ algo = client.algo(<span class="hljs-string">'deeplearning/ColorfulImageColoriza
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/twoimages.js"></script>
-  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/twoimages.js"></script>
+  <script src="<%= slug %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/colorization-demo/index.html
+++ b/JavaScript/colorization-demo/index.html
@@ -3,17 +3,17 @@
 	<%= ga_script %>
 
 	<title>Colorize Black and White Photos – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/colorize-photos/" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
 	<meta name="description" content="Automatically colorize black and white photos, pictures, and images using the Colorful Image Colorization microservice.">
 	<meta name="robots" content="index,follow">
 
 	<!-- FB -->
 	<meta property="og:title" content="Colorize Black and White Photos">
-	<meta property="og:url" content="https://demos.algorithmia.com/colorize-photos/">
+	<meta property="og:url" content="https://demos.algorithmia.com/<%= demo_root %>">
 	<meta property="og:description" content="Automatically colorize black and white photos, pictures, and images using the Colorful Image Colorization microservice">
 	<meta property="og:locale" content="en_US" />
 	<meta property="og:type" content="website" />
-	<meta property="og:image" content="https://demos.algorithmia.com/colorize-photos/public/images/fbshare.png" />
+	<meta property="og:image" content="<%= demo_root %>/public/images/fbshare.png" />
 	<meta property="og:site_name" content="Algorithmia" />
 
 	<!-- TWTR -->
@@ -21,7 +21,7 @@
 	<meta name="twitter:site" content="@algorithmia" />
 	<meta name="twitter:title" content="Colorize Black and White Photos" />
 	<meta name="twitter:description" content="Automatically colorize black and white photos, pictures, and images using the Colorful Image Colorization microservice" />
-	<meta name="twitter:image" content="https://demos.algorithmia.com/colorize-photos/public/images/twshare.png" />
+	<meta name="twitter:image" content="<%= demo_root %>/public/images/twshare.png" />
 	<meta name="twitter:creator" content="@algorithmia" />
 
 	<!-- OTHER -->
@@ -52,19 +52,19 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/e/ef/Ocean_beach_at_low_tide_against_the_sun.jpg')"><img src="public/images/water.png"></a>
+								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/e/ef/Ocean_beach_at_low_tide_against_the_sun.jpg')"><img src="<%= demo_root %>/public/images/water.png"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/c/ce/MaynardYingst_SprintCar.jpg')"><img src="public/images/car.png" class="sample-image"></a>
+								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/c/ce/MaynardYingst_SprintCar.jpg')"><img src="<%= demo_root %>/public/images/car.png" class="sample-image"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/7/7d/Yosemite_(14359652100).jpg')"><img src="public/images/yosemite.png" class="sample-image"></a>
+								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/7/7d/Yosemite_(14359652100).jpg')"><img src="<%= demo_root %>/public/images/yosemite.png" class="sample-image"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/e/e5/Fire-breather_CIELAB_L*.jpg')"><img src="public/images/fire.png" class="sample-image"></a>
+								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/e/e5/Fire-breather_CIELAB_L*.jpg')"><img src="<%= demo_root %>/public/images/fire.png" class="sample-image"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/4/4d/Beef_Portrait_(5210343960).jpg')"><img src="public/images/cows.png" class="sample-image"></a>
+								<a onclick="callAlgorithm('https://upload.wikimedia.org/wikipedia/commons/4/4d/Beef_Portrait_(5210343960).jpg')"><img src="<%= demo_root %>/public/images/cows.png" class="sample-image"></a>
 							</div>
 						</div>
 					</div>

--- a/JavaScript/colorization-demo/index.html
+++ b/JavaScript/colorization-demo/index.html
@@ -151,9 +151,9 @@ algo = client.algo(<span class="hljs-string">'deeplearning/ColorfulImageColoriza
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/twoimages.js"></script>
-  <script src="public/js/dropzone.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/twoimages.js"></script>
+  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/common/footer.html
+++ b/JavaScript/common/footer.html
@@ -55,14 +55,14 @@
 </footer>
 
 <!-- JS -->
-<script src="public/js/jquery.min.js"></script>
-<script src="public/js/bootstrap.min.js"></script>
-<script src="public/js/highlight.pack.js"></script>
+<script src="<%= demo_root %>/public/js/jquery.min.js"></script>
+<script src="<%= demo_root %>/public/js/bootstrap.min.js"></script>
+<script src="<%= demo_root %>/public/js/highlight.pack.js"></script>
 <!-- Algorithmia JavaScript client: https://algorithmia.com/docs/clients/javascript/ -->
-<script src="public/js/algorithmia.js"></script>
+<script src="<%= demo_root %>/public/js/algorithmia.js"></script>
 <!-- Sample App code -->
-<script src="public/js/common.js"></script>
-<script src="public/js/main.js?v=[[VERSION]]"></script>
+<script src="<%= demo_root %>/public/js/common.js"></script>
+<script src="<%= demo_root %>/public/js/main.js?v=[[VERSION]]"></script>
 
 </body>
 </html>

--- a/JavaScript/common/footer.html
+++ b/JavaScript/common/footer.html
@@ -55,14 +55,14 @@
 </footer>
 
 <!-- JS -->
-<script src="<%= demo_root %>/public/js/jquery.min.js"></script>
-<script src="<%= demo_root %>/public/js/bootstrap.min.js"></script>
-<script src="<%= demo_root %>/public/js/highlight.pack.js"></script>
+<script src="<%= slug %>/public/js/jquery.min.js"></script>
+<script src="<%= slug %>/public/js/bootstrap.min.js"></script>
+<script src="<%= slug %>/public/js/highlight.pack.js"></script>
 <!-- Algorithmia JavaScript client: https://algorithmia.com/docs/clients/javascript/ -->
-<script src="<%= demo_root %>/public/js/algorithmia.js"></script>
+<script src="<%= slug %>/public/js/algorithmia.js"></script>
 <!-- Sample App code -->
-<script src="<%= demo_root %>/public/js/common.js"></script>
-<script src="<%= demo_root %>/public/js/main.js?v=[[VERSION]]"></script>
+<script src="<%= slug %>/public/js/common.js"></script>
+<script src="<%= slug %>/public/js/main.js?v=[[VERSION]]"></script>
 
 </body>
 </html>

--- a/JavaScript/common/header_end.html
+++ b/JavaScript/common/header_end.html
@@ -1,13 +1,13 @@
 <!-- CSS -->
-<link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
+<link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700|Raleway:300,400,700" rel="stylesheet">
-<link href="public/css/bootstrap.min.css" rel="stylesheet">
-<link href="public/css/font-awesome/css/font-awesome.min.css" rel="stylesheet">
-<link href="public/css/monokai.css" rel="stylesheet">
-<link href="public/css/all.css?v=[[VERSION]]" rel="stylesheet">
-<link href="public/css/spinner.css" rel="stylesheet">
-<link href="public/css/dots.css" rel="stylesheet">
-<link href="public/css/custom.css?v=[[VERSION]]" rel="stylesheet">
+<link href="<%= demo_root %>/public/css/bootstrap.min.css" rel="stylesheet">
+<link href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css" rel="stylesheet">
+<link href="<%= demo_root %>/public/css/monokai.css" rel="stylesheet">
+<link href="<%= demo_root %>/public/css/all.css?v=[[VERSION]]" rel="stylesheet">
+<link href="<%= demo_root %>/public/css/spinner.css" rel="stylesheet">
+<link href="<%= demo_root %>/public/css/dots.css" rel="stylesheet">
+<link href="<%= demo_root %>/public/css/custom.css?v=[[VERSION]]" rel="stylesheet">
 
 </head>
 
@@ -23,7 +23,7 @@
         <span class="icon-bar"></span>
       </button>
       <a class="navbar-brand" href="">
-        <img src="public/images/algoWhite.svg" alt="Algorithmia">
+        <img src="<%= demo_root %>/public/images/algoWhite.svg" alt="Algorithmia">
       </a>
     </div>
     <div class="navbar-collapse collapse">

--- a/JavaScript/common/header_end.html
+++ b/JavaScript/common/header_end.html
@@ -1,13 +1,13 @@
 <!-- CSS -->
-<link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+<link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700|Raleway:300,400,700" rel="stylesheet">
-<link href="<%= demo_root %>/public/css/bootstrap.min.css" rel="stylesheet">
-<link href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css" rel="stylesheet">
-<link href="<%= demo_root %>/public/css/monokai.css" rel="stylesheet">
-<link href="<%= demo_root %>/public/css/all.css?v=[[VERSION]]" rel="stylesheet">
-<link href="<%= demo_root %>/public/css/spinner.css" rel="stylesheet">
-<link href="<%= demo_root %>/public/css/dots.css" rel="stylesheet">
-<link href="<%= demo_root %>/public/css/custom.css?v=[[VERSION]]" rel="stylesheet">
+<link href="<%= slug %>/public/css/bootstrap.min.css" rel="stylesheet">
+<link href="<%= slug %>/public/css/font-awesome/css/font-awesome.min.css" rel="stylesheet">
+<link href="<%= slug %>/public/css/monokai.css" rel="stylesheet">
+<link href="<%= slug %>/public/css/all.css?v=[[VERSION]]" rel="stylesheet">
+<link href="<%= slug %>/public/css/spinner.css" rel="stylesheet">
+<link href="<%= slug %>/public/css/dots.css" rel="stylesheet">
+<link href="<%= slug %>/public/css/custom.css?v=[[VERSION]]" rel="stylesheet">
 
 </head>
 
@@ -23,7 +23,7 @@
         <span class="icon-bar"></span>
       </button>
       <a class="navbar-brand" href="">
-        <img src="<%= demo_root %>/public/images/algoWhite.svg" alt="Algorithmia">
+        <img src="<%= slug %>/public/images/algoWhite.svg" alt="Algorithmia">
       </a>
     </div>
     <div class="navbar-collapse collapse">

--- a/JavaScript/deep-fashion/index.html
+++ b/JavaScript/deep-fashion/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 	<title>Deep Learning to Classify Clothing and Fashion Items in Images – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/deep-fashion/" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
 	<meta name="description" content="Use deep learning algorithms to identify clothing and accessories in images with the Fashion Classifier microservice">
 	<meta name="robots" content="index,follow">
 
@@ -50,19 +50,19 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion1.jpg')"><img src="public/images/fashion1_sm.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion1.jpg')"><img src="<%= demo_root %>/public/images/fashion1_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion2.jpg')"><img src="public/images/fashion2_sm.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion2.jpg')"><img src="<%= demo_root %>/public/images/fashion2_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion3.jpg')"><img src="public/images/fashion3_sm.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion3.jpg')"><img src="<%= demo_root %>/public/images/fashion3_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion4.jpg')"><img src="public/images/fashion4_sm.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion4.jpg')"><img src="<%= demo_root %>/public/images/fashion4_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion5.jpg')"><img src="public/images/fashion5_sm.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion5.jpg')"><img src="<%= demo_root %>/public/images/fashion5_sm.jpg"></a>
 							</div>
 						</div>
 					</div>
@@ -164,8 +164,8 @@ algo = client.algo(<span class="hljs-string">'algorithmiahq/DeepFashion/1.2.2'</
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/dropzone.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/deep-fashion/index.html
+++ b/JavaScript/deep-fashion/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 	<title>Deep Learning to Classify Clothing and Fashion Items in Images – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>" />
 	<meta name="description" content="Use deep learning algorithms to identify clothing and accessories in images with the Fashion Classifier microservice">
 	<meta name="robots" content="index,follow">
 
@@ -50,19 +50,19 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion1.jpg')"><img src="<%= demo_root %>/public/images/fashion1_sm.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion1.jpg')"><img src="<%= slug %>/public/images/fashion1_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion2.jpg')"><img src="<%= demo_root %>/public/images/fashion2_sm.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion2.jpg')"><img src="<%= slug %>/public/images/fashion2_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion3.jpg')"><img src="<%= demo_root %>/public/images/fashion3_sm.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion3.jpg')"><img src="<%= slug %>/public/images/fashion3_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion4.jpg')"><img src="<%= demo_root %>/public/images/fashion4_sm.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion4.jpg')"><img src="<%= slug %>/public/images/fashion4_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion5.jpg')"><img src="<%= demo_root %>/public/images/fashion5_sm.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/fashion5.jpg')"><img src="<%= slug %>/public/images/fashion5_sm.jpg"></a>
 							</div>
 						</div>
 					</div>
@@ -164,8 +164,8 @@ algo = client.algo(<span class="hljs-string">'algorithmiahq/DeepFashion/1.2.2'</
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/deep-filter/index.html
+++ b/JavaScript/deep-filter/index.html
@@ -6,7 +6,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>Style Transfer Using Deep Learning – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/deep-style/" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
 	<meta name="description" content="Reimagine images in new artistic styles using deep learning and style transfer.">
 	<meta name="robots" content="index,follow">
 
@@ -32,11 +32,11 @@
 	<meta itemprop="description" content="Reimagine images in new artistic styles using deep learning and style transfer.">
 
 	<!-- CSS -->
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
-	<link href="public/css/bootstrap.min.css" rel="stylesheet">
-	<link href="public/css/all.css" rel="stylesheet">
-	<link href="public/css/custom.css" rel="stylesheet">
-	<link href="public/css/styles/monokai.css" rel="stylesheet">
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+	<link href="<%= demo_root %>/public/css/bootstrap.min.css" rel="stylesheet">
+	<link href="<%= demo_root %>/public/css/all.css" rel="stylesheet">
+	<link href="<%= demo_root %>/public/css/custom.css" rel="stylesheet">
+	<link href="<%= demo_root %>/public/css/styles/monokai.css" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400|Raleway:300,400" rel="stylesheet">
 
 	<!--   Google Analytics -->
@@ -62,7 +62,7 @@
 					<span class="icon-bar"></span>
 				</button>
 				<a class="navbar-brand" href="https://algorithmia.com/">
-					<img src="public/images/algoWhite.svg" alt="Algorithmia">
+					<img src="<%= demo_root %>/public/images/algoWhite.svg" alt="Algorithmia">
 				</a>
 			</div>
 			<div class="navbar-collapse collapse">
@@ -109,16 +109,16 @@
 						<h4 class="has-subcontent">Or, filter a sample image</h4>
 						<div class="row">
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center">
-								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1479088360436-ef9dbade3214?w=1600&ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=b37ce33a6c3b8540e2386b7feceb02ef')"><img src="public/images/sample01.jpeg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1479088360436-ef9dbade3214?w=1600&ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=b37ce33a6c3b8540e2386b7feceb02ef')"><img src="<%= demo_root %>/public/images/sample01.jpeg" class="sample-img"></a>
 							</div>
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center">
-								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?dpr=2&auto=format&fit=crop&w=1500&h=1000&q=80&cs=tinysrgb&crop=')"><img src="public/images/sample02.jpeg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?dpr=2&auto=format&fit=crop&w=1500&h=1000&q=80&cs=tinysrgb&crop=')"><img src="<%= demo_root %>/public/images/sample02.jpeg" class="sample-img"></a>
 							</div>
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center">
-								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1430026996702-608b84ce9281?w=1600&ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=bc612c816d9b222124db4eb20ee53c6c')"><img src="public/images/sample03.jpeg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1430026996702-608b84ce9281?w=1600&ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=bc612c816d9b222124db4eb20ee53c6c')"><img src="<%= demo_root %>/public/images/sample03.jpeg" class="sample-img"></a>
 							</div>
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center">
-								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1466657718950-8f9346c04f8f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=42f94fdaf70349ae0cf274c9aa8d0a41')"><img src="public/images/sample04.jpeg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1466657718950-8f9346c04f8f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=42f94fdaf70349ae0cf274c9aa8d0a41')"><img src="<%= demo_root %>/public/images/sample04.jpeg" class="sample-img"></a>
 							</div>
 						</div>
 					</div>
@@ -156,8 +156,8 @@
 				</div>
 				<!-- <span class="download"><a href=""><span class="glyphicon glyphicon-download" aria-hidden="true"></span> DOWNLOAD</a></span> -->
 				<span class="share">
-					<a href="https://twitter.com/intent/tweet?text=Style Transfer Using Deep Learning https://demos.algorithmia.com/deep-style/ @Algorithmia"><img src="public/images/twitter.svg"></a>
-					<a href="https://www.facebook.com/sharer/sharer.php?u=https://demos.algorithmia.com/deep-style/"><img src="public/images/facebook.svg"></a></a>
+					<a href="https://twitter.com/intent/tweet?text=Style Transfer Using Deep Learning https://demos.algorithmia.com/deep-style/ @Algorithmia"><img src="<%= demo_root %>/public/images/twitter.svg"></a>
+					<a href="https://www.facebook.com/sharer/sharer.php?u=https://demos.algorithmia.com/deep-style/"><img src="<%= demo_root %>/public/images/facebook.svg"></a></a>
 				</span>
 			</div>
 			<!-- THUMBNAILS -->
@@ -165,27 +165,27 @@
 				<div class="tab-pane active" id="filters" role="tabpanel">
 					<div class="row thumbnails">
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="none">
-							<img src="public/images/thumb/unfiltered.jpg">
+							<img src="<%= demo_root %>/public/images/thumb/unfiltered.jpg">
 							<p class="secondary">Unfiltered</p>
 						</div>
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="smooth_ride">
-							<img src="public/images/thumb/smooth_ride.jpg">
+							<img src="<%= demo_root %>/public/images/thumb/smooth_ride.jpg">
 							<p class="secondary">Smooth Ride</p>
 						</div>
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="crafty_painting">
-							<img src="public/images/thumb/crafty_painting.jpg">
+							<img src="<%= demo_root %>/public/images/thumb/crafty_painting.jpg">
 							<p class="secondary">Crafty Painting</p>
 						</div>
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="purple_pond">
-							<img src="public/images/thumb/purple_pond.jpg">
+							<img src="<%= demo_root %>/public/images/thumb/purple_pond.jpg">
 							<p class="secondary">Purple Pond</p>
 						</div>
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="sunday">
-							<img src="public/images/thumb/sunday.jpg">
+							<img src="<%= demo_root %>/public/images/thumb/sunday.jpg">
 							<p class="secondary">Sunday</p>
 						</div>
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="oily_mcoilface">
-							<img src="public/images/thumb/oily_mcoilface.jpg">
+							<img src="<%= demo_root %>/public/images/thumb/oily_mcoilface.jpg">
 							<p class="secondary">Oily McOilface</p>
 						</div>
 					</div>
@@ -315,14 +315,14 @@ print algo.pipe(input)
 	</footer>
 
 	<!-- JS -->
-	<script src="public/js/jquery.min.js"></script>
-	<script src="public/js/bootstrap.min.js"></script>
-	<script src="public/js/TweenMax.min.js"></script>
-    <script src="public/js/dots.js"></script>
-	<script src="public/js/algorithmia-0.2.0.js"></script>
-	<script src="public/js/highlight.pack.js"></script>
-	<script src="public/js/dropzone.js"></script>
-	<script src="public/js/main.js"></script>
+	<script src="<%= demo_root %>/public/js/jquery.min.js"></script>
+	<script src="<%= demo_root %>/public/js/bootstrap.min.js"></script>
+	<script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+    <script src="<%= demo_root %>/public/js/dots.js"></script>
+	<script src="<%= demo_root %>/public/js/algorithmia-0.2.0.js"></script>
+	<script src="<%= demo_root %>/public/js/highlight.pack.js"></script>
+	<script src="<%= demo_root %>/public/js/dropzone.js"></script>
+	<script src="<%= demo_root %>/public/js/main.js"></script>
 	<script>hljs.initHighlightingOnLoad();</script>
 	<script>
 	  window.intercomSettings = {

--- a/JavaScript/deep-filter/index.html
+++ b/JavaScript/deep-filter/index.html
@@ -6,7 +6,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 	<title>Style Transfer Using Deep Learning – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>" />
 	<meta name="description" content="Reimagine images in new artistic styles using deep learning and style transfer.">
 	<meta name="robots" content="index,follow">
 
@@ -32,11 +32,11 @@
 	<meta itemprop="description" content="Reimagine images in new artistic styles using deep learning and style transfer.">
 
 	<!-- CSS -->
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
-	<link href="<%= demo_root %>/public/css/bootstrap.min.css" rel="stylesheet">
-	<link href="<%= demo_root %>/public/css/all.css" rel="stylesheet">
-	<link href="<%= demo_root %>/public/css/custom.css" rel="stylesheet">
-	<link href="<%= demo_root %>/public/css/styles/monokai.css" rel="stylesheet">
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
+	<link href="<%= slug %>/public/css/bootstrap.min.css" rel="stylesheet">
+	<link href="<%= slug %>/public/css/all.css" rel="stylesheet">
+	<link href="<%= slug %>/public/css/custom.css" rel="stylesheet">
+	<link href="<%= slug %>/public/css/styles/monokai.css" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400|Raleway:300,400" rel="stylesheet">
 
 	<!--   Google Analytics -->
@@ -62,7 +62,7 @@
 					<span class="icon-bar"></span>
 				</button>
 				<a class="navbar-brand" href="https://algorithmia.com/">
-					<img src="<%= demo_root %>/public/images/algoWhite.svg" alt="Algorithmia">
+					<img src="<%= slug %>/public/images/algoWhite.svg" alt="Algorithmia">
 				</a>
 			</div>
 			<div class="navbar-collapse collapse">
@@ -109,16 +109,16 @@
 						<h4 class="has-subcontent">Or, filter a sample image</h4>
 						<div class="row">
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center">
-								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1479088360436-ef9dbade3214?w=1600&ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=b37ce33a6c3b8540e2386b7feceb02ef')"><img src="<%= demo_root %>/public/images/sample01.jpeg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1479088360436-ef9dbade3214?w=1600&ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=b37ce33a6c3b8540e2386b7feceb02ef')"><img src="<%= slug %>/public/images/sample01.jpeg" class="sample-img"></a>
 							</div>
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center">
-								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?dpr=2&auto=format&fit=crop&w=1500&h=1000&q=80&cs=tinysrgb&crop=')"><img src="<%= demo_root %>/public/images/sample02.jpeg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?dpr=2&auto=format&fit=crop&w=1500&h=1000&q=80&cs=tinysrgb&crop=')"><img src="<%= slug %>/public/images/sample02.jpeg" class="sample-img"></a>
 							</div>
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center">
-								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1430026996702-608b84ce9281?w=1600&ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=bc612c816d9b222124db4eb20ee53c6c')"><img src="<%= demo_root %>/public/images/sample03.jpeg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1430026996702-608b84ce9281?w=1600&ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=bc612c816d9b222124db4eb20ee53c6c')"><img src="<%= slug %>/public/images/sample03.jpeg" class="sample-img"></a>
 							</div>
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center">
-								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1466657718950-8f9346c04f8f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=42f94fdaf70349ae0cf274c9aa8d0a41')"><img src="<%= demo_root %>/public/images/sample04.jpeg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://images.unsplash.com/photo-1466657718950-8f9346c04f8f?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=42f94fdaf70349ae0cf274c9aa8d0a41')"><img src="<%= slug %>/public/images/sample04.jpeg" class="sample-img"></a>
 							</div>
 						</div>
 					</div>
@@ -156,8 +156,8 @@
 				</div>
 				<!-- <span class="download"><a href=""><span class="glyphicon glyphicon-download" aria-hidden="true"></span> DOWNLOAD</a></span> -->
 				<span class="share">
-					<a href="https://twitter.com/intent/tweet?text=Style Transfer Using Deep Learning https://demos.algorithmia.com/deep-style/ @Algorithmia"><img src="<%= demo_root %>/public/images/twitter.svg"></a>
-					<a href="https://www.facebook.com/sharer/sharer.php?u=https://demos.algorithmia.com/deep-style/"><img src="<%= demo_root %>/public/images/facebook.svg"></a></a>
+					<a href="https://twitter.com/intent/tweet?text=Style Transfer Using Deep Learning https://demos.algorithmia.com/deep-style/ @Algorithmia"><img src="<%= slug %>/public/images/twitter.svg"></a>
+					<a href="https://www.facebook.com/sharer/sharer.php?u=https://demos.algorithmia.com/deep-style/"><img src="<%= slug %>/public/images/facebook.svg"></a></a>
 				</span>
 			</div>
 			<!-- THUMBNAILS -->
@@ -165,27 +165,27 @@
 				<div class="tab-pane active" id="filters" role="tabpanel">
 					<div class="row thumbnails">
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="none">
-							<img src="<%= demo_root %>/public/images/thumb/unfiltered.jpg">
+							<img src="<%= slug %>/public/images/thumb/unfiltered.jpg">
 							<p class="secondary">Unfiltered</p>
 						</div>
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="smooth_ride">
-							<img src="<%= demo_root %>/public/images/thumb/smooth_ride.jpg">
+							<img src="<%= slug %>/public/images/thumb/smooth_ride.jpg">
 							<p class="secondary">Smooth Ride</p>
 						</div>
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="crafty_painting">
-							<img src="<%= demo_root %>/public/images/thumb/crafty_painting.jpg">
+							<img src="<%= slug %>/public/images/thumb/crafty_painting.jpg">
 							<p class="secondary">Crafty Painting</p>
 						</div>
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="purple_pond">
-							<img src="<%= demo_root %>/public/images/thumb/purple_pond.jpg">
+							<img src="<%= slug %>/public/images/thumb/purple_pond.jpg">
 							<p class="secondary">Purple Pond</p>
 						</div>
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="sunday">
-							<img src="<%= demo_root %>/public/images/thumb/sunday.jpg">
+							<img src="<%= slug %>/public/images/thumb/sunday.jpg">
 							<p class="secondary">Sunday</p>
 						</div>
 						<div class="col-xs-6 col-sm-4 col-md-2 thumb style-thumb" data-style="oily_mcoilface">
-							<img src="<%= demo_root %>/public/images/thumb/oily_mcoilface.jpg">
+							<img src="<%= slug %>/public/images/thumb/oily_mcoilface.jpg">
 							<p class="secondary">Oily McOilface</p>
 						</div>
 					</div>
@@ -315,14 +315,14 @@ print algo.pipe(input)
 	</footer>
 
 	<!-- JS -->
-	<script src="<%= demo_root %>/public/js/jquery.min.js"></script>
-	<script src="<%= demo_root %>/public/js/bootstrap.min.js"></script>
-	<script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-    <script src="<%= demo_root %>/public/js/dots.js"></script>
-	<script src="<%= demo_root %>/public/js/algorithmia-0.2.0.js"></script>
-	<script src="<%= demo_root %>/public/js/highlight.pack.js"></script>
-	<script src="<%= demo_root %>/public/js/dropzone.js"></script>
-	<script src="<%= demo_root %>/public/js/main.js"></script>
+	<script src="<%= slug %>/public/js/jquery.min.js"></script>
+	<script src="<%= slug %>/public/js/bootstrap.min.js"></script>
+	<script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+    <script src="<%= slug %>/public/js/dots.js"></script>
+	<script src="<%= slug %>/public/js/algorithmia-0.2.0.js"></script>
+	<script src="<%= slug %>/public/js/highlight.pack.js"></script>
+	<script src="<%= slug %>/public/js/dropzone.js"></script>
+	<script src="<%= slug %>/public/js/main.js"></script>
 	<script>hljs.initHighlightingOnLoad();</script>
 	<script>
 	  window.intercomSettings = {

--- a/JavaScript/doc-classifier/index.html
+++ b/JavaScript/doc-classifier/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>Document Classifier - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/doc-classifier/">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
 <meta name="description" content="Train a Machine to Recognize User Input, and Classify it into Custom Keywords or Responses"/>
 <meta name="robots" content="index,follow">
 
@@ -191,8 +191,8 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/dropzone.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/doc-classifier/index.html
+++ b/JavaScript/doc-classifier/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>Document Classifier - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>">
 <meta name="description" content="Train a Machine to Recognize User Input, and Classify it into Custom Keywords or Responses"/>
 <meta name="robots" content="index,follow">
 
@@ -191,8 +191,8 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/dummy-project/index.html
+++ b/JavaScript/dummy-project/index.html
@@ -4,7 +4,7 @@
 
 <title>RSS Dashboard - Algorithmia</title>
 
-<link rel="canonical" href="https://demos.algorithmia.com/rss-dashboard/">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
 <meta name="description" content="Automatically create summaries, extract tags, and analyze the sentiment of RSS feeds with this microservice.">
 
 <!-- FB -->

--- a/JavaScript/dummy-project/index.html
+++ b/JavaScript/dummy-project/index.html
@@ -4,7 +4,7 @@
 
 <title>RSS Dashboard - Algorithmia</title>
 
-<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>">
 <meta name="description" content="Automatically create summaries, extract tags, and analyze the sentiment of RSS feeds with this microservice.">
 
 <!-- FB -->

--- a/JavaScript/flow/index.html
+++ b/JavaScript/flow/index.html
@@ -24,18 +24,18 @@
 
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.js" type="text/javascript"></script>
   </head>
   <body>
-    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/core.cat.min.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/core.cat.min.js" type="text/javascript"></script>
     <div class="container content-container">
       <div class="well" ng-controller="FlowControl">
         <header>Algorithmia Work Flow Designer</header>
@@ -92,8 +92,8 @@ FlowOutput :=
         </div>
 
       </div>
-      <script src="<%= demo_root %>/public/js/algorithmia.data.js" type="text/javascript"></script>
-      <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/algorithmia.data.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/main.js" type="text/javascript"></script>
       <style>
         .flow-json {
           max-width: 100%;

--- a/JavaScript/flow/index.html
+++ b/JavaScript/flow/index.html
@@ -24,18 +24,18 @@
 
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="public/css/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <script src="public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
   </head>
   <body>
-    <script src="public/js/common.cat.js" type="text/javascript"></script>
-    <script src="public/js/core.cat.min.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/core.cat.min.js" type="text/javascript"></script>
     <div class="container content-container">
       <div class="well" ng-controller="FlowControl">
         <header>Algorithmia Work Flow Designer</header>
@@ -92,8 +92,8 @@ FlowOutput :=
         </div>
 
       </div>
-      <script src="public/js/algorithmia.data.js" type="text/javascript"></script>
-      <script src="public/js/main.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/algorithmia.data.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
       <style>
         .flow-json {
           max-width: 100%;

--- a/JavaScript/github/index.html
+++ b/JavaScript/github/index.html
@@ -2,11 +2,11 @@
   <head>
     <title>GitHub Recommender - Algorithmia</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,300,400,600,700" rel="stylesheet" type="text/css">
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
-    <link rel="stylesheet" href="public/css/font-awesome/css/font-awesome.min.css" type="text/css">
-    <link rel="stylesheet" media="screen" href="public/css/bootstrap3.min.css">
-    <link rel="stylesheet" media="screen" href="public/css/algo.min.css">
-    <script src="public/js/algorithmia.js"></script>
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css" type="text/css">
+    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/bootstrap3.min.css">
+    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/algo.min.css">
+    <script src="<%= demo_root %>/public/js/algorithmia.js"></script>
     <style>
     a {
       /* blog colors */
@@ -91,6 +91,6 @@
       </div>
     </div>
 
-  <script src="public/js/main.js" type="text/javascript"></script>
+  <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
   </body>
 </html>

--- a/JavaScript/github/index.html
+++ b/JavaScript/github/index.html
@@ -2,11 +2,11 @@
   <head>
     <title>GitHub Recommender - Algorithmia</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,300,400,600,700" rel="stylesheet" type="text/css">
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css" type="text/css">
-    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/bootstrap3.min.css">
-    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/algo.min.css">
-    <script src="<%= demo_root %>/public/js/algorithmia.js"></script>
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="stylesheet" href="<%= slug %>/public/css/font-awesome/css/font-awesome.min.css" type="text/css">
+    <link rel="stylesheet" media="screen" href="<%= slug %>/public/css/bootstrap3.min.css">
+    <link rel="stylesheet" media="screen" href="<%= slug %>/public/css/algo.min.css">
+    <script src="<%= slug %>/public/js/algorithmia.js"></script>
     <style>
     a {
       /* blog colors */
@@ -91,6 +91,6 @@
       </div>
     </div>
 
-  <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
+  <script src="<%= slug %>/public/js/main.js" type="text/javascript"></script>
   </body>
 </html>

--- a/JavaScript/hacker-news/index.html
+++ b/JavaScript/hacker-news/index.html
@@ -4,9 +4,9 @@
     <link rel="stylesheet" type="text/css" href="https://news.ycombinator.com/news.css">
     <link rel="shortcut icon" href="https://news.ycombinator.com/favicon.ico">
     <title>Hacker News</title>
-    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
-    <link rel="stylesheet" type="text/css" href="<%= demo_root %>/public/css/hn.css">
+    <script src="<%= slug %>/public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/main.js" type="text/javascript"></script>
+    <link rel="stylesheet" type="text/css" href="<%= slug %>/public/css/hn.css">
   </head>
   <body onload="scrape()">
     <center>

--- a/JavaScript/hacker-news/index.html
+++ b/JavaScript/hacker-news/index.html
@@ -4,9 +4,9 @@
     <link rel="stylesheet" type="text/css" href="https://news.ycombinator.com/news.css">
     <link rel="shortcut icon" href="https://news.ycombinator.com/favicon.ico">
     <title>Hacker News</title>
-    <script src="public/js/algorithmia.js" type="text/javascript"></script>
-    <script src="public/js/main.js" type="text/javascript"></script>
-    <link rel="stylesheet" type="text/css" href="public/css/hn.css">
+    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
+    <link rel="stylesheet" type="text/css" href="<%= demo_root %>/public/css/hn.css">
   </head>
   <body onload="scrape()">
     <center>

--- a/JavaScript/handwriting/index.html
+++ b/JavaScript/handwriting/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
 <title>Algorithmia Handwriting Recognition Demo</title>
-<link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
-<link rel="stylesheet" media="screen" href="public/css/algo.min.css">
-<link rel="stylesheet" media="screen" href="public/css/bootstrap3.min.css">
+<link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+<link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/algo.min.css">
+<link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/bootstrap3.min.css">
 <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
-<script src="public/js/algorithmia.js"></script>
-<script src="public/js/main.js" type="text/javascript"></script>
+<script src="<%= demo_root %>/public/js/algorithmia.js"></script>
+<script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
 <style>
   table {
     border-collapse: separate;

--- a/JavaScript/handwriting/index.html
+++ b/JavaScript/handwriting/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
 <title>Algorithmia Handwriting Recognition Demo</title>
-<link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
-<link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/algo.min.css">
-<link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/bootstrap3.min.css">
+<link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
+<link rel="stylesheet" media="screen" href="<%= slug %>/public/css/algo.min.css">
+<link rel="stylesheet" media="screen" href="<%= slug %>/public/css/bootstrap3.min.css">
 <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
-<script src="<%= demo_root %>/public/js/algorithmia.js"></script>
-<script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
+<script src="<%= slug %>/public/js/algorithmia.js"></script>
+<script src="<%= slug %>/public/js/main.js" type="text/javascript"></script>
 <style>
   table {
     border-collapse: separate;

--- a/JavaScript/image-tagger/index.html
+++ b/JavaScript/image-tagger/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 	<title>Deep Learning to Identify Features and Automatically Tag in an Image – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/image-tagger/" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
 	<meta name="description" content="Use deep learning algorithms to identify features and assign tags with Illustration Tagging microservices">
 	<meta name="robots" content="index,follow">
 
@@ -50,22 +50,22 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/dog.jpg')"><img src="public/images/dog.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/dog.jpg')"><img src="<%= demo_root %>/public/images/dog.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/yosemite.jpg')"><img src="public/images/yosemite.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/yosemite.jpg')"><img src="<%= demo_root %>/public/images/yosemite.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/obama.jpg')"><img src="public/images/obama.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/obama.jpg')"><img src="<%= demo_root %>/public/images/obama.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/train.jpg')"><img src="public/images/train.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/train.jpg')"><img src="<%= demo_root %>/public/images/train.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/convertible.jpg')"><img src="public/images/convertible.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/convertible.jpg')"><img src="<%= demo_root %>/public/images/convertible.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/modelcar.jpg')"><img src="public/images/modelcar.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/modelcar.jpg')"><img src="<%= demo_root %>/public/images/modelcar.jpg"></a>
 							</div>
 						</div>
 					</div>
@@ -189,8 +189,8 @@ tagger2 = client.algo(<span class="hljs-string">"deeplearning/InceptionNet/1.0.3
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/dropzone.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/image-tagger/index.html
+++ b/JavaScript/image-tagger/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 	<title>Deep Learning to Identify Features and Automatically Tag in an Image – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>" />
 	<meta name="description" content="Use deep learning algorithms to identify features and assign tags with Illustration Tagging microservices">
 	<meta name="robots" content="index,follow">
 
@@ -50,22 +50,22 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/dog.jpg')"><img src="<%= demo_root %>/public/images/dog.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/dog.jpg')"><img src="<%= slug %>/public/images/dog.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/yosemite.jpg')"><img src="<%= demo_root %>/public/images/yosemite.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/yosemite.jpg')"><img src="<%= slug %>/public/images/yosemite.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/obama.jpg')"><img src="<%= demo_root %>/public/images/obama.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/obama.jpg')"><img src="<%= slug %>/public/images/obama.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/train.jpg')"><img src="<%= demo_root %>/public/images/train.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/train.jpg')"><img src="<%= slug %>/public/images/train.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/convertible.jpg')"><img src="<%= demo_root %>/public/images/convertible.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/convertible.jpg')"><img src="<%= slug %>/public/images/convertible.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/modelcar.jpg')"><img src="<%= demo_root %>/public/images/modelcar.jpg"></a>
+								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/modelcar.jpg')"><img src="<%= slug %>/public/images/modelcar.jpg"></a>
 							</div>
 						</div>
 					</div>
@@ -189,8 +189,8 @@ tagger2 = client.algo(<span class="hljs-string">"deeplearning/InceptionNet/1.0.3
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/isitnude/index.html
+++ b/JavaScript/isitnude/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>#isitnude - nudity detector - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/isitnude/">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
 <meta name="description" content="Machine-learning microservice for detecting nudity in images"/>
 <meta name="robots" content="index,follow">
 
@@ -53,19 +53,19 @@
             <h4 class="dark whitespace-sm">Or, try these sample images:</h4>
             <div class="row whitespace-none sample-images">
               <div class="col-xs-4 col-sm-2">
-                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/sunglasses-love-woman-flowers.jpg')"><img src="public/images/thumb01.png" alt="woman"></a>
+                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/sunglasses-love-woman-flowers.jpg')"><img src="<%= demo_root %>/public/images/thumb01.png" alt="woman"></a>
               </div>
               <div class="col-xs-4 col-sm-2 sample-image">
-                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/obama.jpg')"><img src="public/images/thumb02.png" alt="Obama Swimsuit"></a>
+                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/obama.jpg')"><img src="<%= demo_root %>/public/images/thumb02.png" alt="Obama Swimsuit"></a>
               </div>
               <div class="col-xs-4 col-sm-2 sample-image">
-                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/venus.jpg')"><img src="public/images/thumb03.png" alt="The Birth of Venus"></a>
+                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/venus.jpg')"><img src="<%= demo_root %>/public/images/thumb03.png" alt="The Birth of Venus"></a>
               </div>
               <div class="col-xs-4 col-sm-2 sample-image">
-                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/family-guy.jpg')"><img src="public/images/thumb04.jpg" alt="Family Guy Peter"></a>
+                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/family-guy.jpg')"><img src="<%= demo_root %>/public/images/thumb04.jpg" alt="Family Guy Peter"></a>
               </div>
               <div class="col-xs-4 col-sm-2 sample-image">
-                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/cosimo-medici-orpheus.jpg')"><img src="public/images/thumb05.png" alt="Cosimo Medici as Orpheus"></a>
+                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/cosimo-medici-orpheus.jpg')"><img src="<%= demo_root %>/public/images/thumb05.png" alt="Cosimo Medici as Orpheus"></a>
               </div>
             </div>
           </div>
@@ -159,8 +159,8 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/dropzone.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/isitnude/index.html
+++ b/JavaScript/isitnude/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>#isitnude - nudity detector - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>">
 <meta name="description" content="Machine-learning microservice for detecting nudity in images"/>
 <meta name="robots" content="index,follow">
 
@@ -53,19 +53,19 @@
             <h4 class="dark whitespace-sm">Or, try these sample images:</h4>
             <div class="row whitespace-none sample-images">
               <div class="col-xs-4 col-sm-2">
-                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/sunglasses-love-woman-flowers.jpg')"><img src="<%= demo_root %>/public/images/thumb01.png" alt="woman"></a>
+                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/sunglasses-love-woman-flowers.jpg')"><img src="<%= slug %>/public/images/thumb01.png" alt="woman"></a>
               </div>
               <div class="col-xs-4 col-sm-2 sample-image">
-                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/obama.jpg')"><img src="<%= demo_root %>/public/images/thumb02.png" alt="Obama Swimsuit"></a>
+                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/obama.jpg')"><img src="<%= slug %>/public/images/thumb02.png" alt="Obama Swimsuit"></a>
               </div>
               <div class="col-xs-4 col-sm-2 sample-image">
-                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/venus.jpg')"><img src="<%= demo_root %>/public/images/thumb03.png" alt="The Birth of Venus"></a>
+                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/venus.jpg')"><img src="<%= slug %>/public/images/thumb03.png" alt="The Birth of Venus"></a>
               </div>
               <div class="col-xs-4 col-sm-2 sample-image">
-                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/family-guy.jpg')"><img src="<%= demo_root %>/public/images/thumb04.jpg" alt="Family Guy Peter"></a>
+                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/family-guy.jpg')"><img src="<%= slug %>/public/images/thumb04.jpg" alt="Family Guy Peter"></a>
               </div>
               <div class="col-xs-4 col-sm-2 sample-image">
-                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/cosimo-medici-orpheus.jpg')"><img src="<%= demo_root %>/public/images/thumb05.png" alt="Cosimo Medici as Orpheus"></a>
+                <a onclick="analyzeImage('http://www.isitnude.com.s3-website-us-east-1.amazonaws.com/assets/images/sample/cosimo-medici-orpheus.jpg')"><img src="<%= slug %>/public/images/thumb05.png" alt="Cosimo Medici as Orpheus"></a>
               </div>
             </div>
           </div>
@@ -159,8 +159,8 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/json/index.html
+++ b/JavaScript/json/index.html
@@ -23,16 +23,16 @@
 
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
   </head>
   <body>
-    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/core.cat.min.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/core.cat.min.js" type="text/javascript"></script>
     <div class="container content-container">
       <div class="well" ng-controller="JsonControl" ng-init="initDrag()">
         <header>Algorithmia JSON Transformer</header>
@@ -75,8 +75,8 @@
         <div class="overlay"></div>
 
       </div>
-      <script src="<%= demo_root %>/public/js/algorithmia.data.js" type="text/javascript"></script>
-      <script src="<%= demo_root %>/public/js/main.js"></script>
+      <script src="<%= slug %>/public/js/algorithmia.data.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/main.js"></script>
       <style>
         .json-view {
           min-height: 40px;

--- a/JavaScript/json/index.html
+++ b/JavaScript/json/index.html
@@ -23,16 +23,16 @@
 
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="public/css/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
   </head>
   <body>
-    <script src="public/js/common.cat.js" type="text/javascript"></script>
-    <script src="public/js/core.cat.min.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/core.cat.min.js" type="text/javascript"></script>
     <div class="container content-container">
       <div class="well" ng-controller="JsonControl" ng-init="initDrag()">
         <header>Algorithmia JSON Transformer</header>
@@ -75,8 +75,8 @@
         <div class="overlay"></div>
 
       </div>
-      <script src="public/js/algorithmia.data.js" type="text/javascript"></script>
-      <script src="public/js/main.js"></script>
+      <script src="<%= demo_root %>/public/js/algorithmia.data.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/main.js"></script>
       <style>
         .json-view {
           min-height: 40px;

--- a/JavaScript/lda/index.html
+++ b/JavaScript/lda/index.html
@@ -24,17 +24,17 @@
 
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.js" type="text/javascript"></script>
   </head>
   <body>
-    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/common.cat.js" type="text/javascript"></script>
     <div class="container content-container">
       <div class="well">
         <header>Algorithmia Topic Analysis</header>
@@ -99,9 +99,9 @@ Algorithmia.client(apiKey).algo("/diego/GetTweetsWithKeyword").pipe(searchString
         fill: white;
       }
       </style>
-      <script src="<%= demo_root %>/public/js/d3.min.js" type="text/javascript"></script>
-      <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
-      <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/d3.min.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/main.js" type="text/javascript"></script>
     </div>
   </body>
 </html>

--- a/JavaScript/lda/index.html
+++ b/JavaScript/lda/index.html
@@ -24,17 +24,17 @@
 
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="public/css/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <script src="public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
   </head>
   <body>
-    <script src="public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
     <div class="container content-container">
       <div class="well">
         <header>Algorithmia Topic Analysis</header>
@@ -99,9 +99,9 @@ Algorithmia.client(apiKey).algo("/diego/GetTweetsWithKeyword").pipe(searchString
         fill: white;
       }
       </style>
-      <script src="public/js/d3.min.js" type="text/javascript"></script>
-      <script src="public/js/algorithmia.d3.js" type="text/javascript"></script>
-      <script src="public/js/main.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/d3.min.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
     </div>
   </body>
 </html>

--- a/JavaScript/lda2/index.html
+++ b/JavaScript/lda2/index.html
@@ -24,17 +24,17 @@
 
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="public/css/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <script src="public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
   </head>
   <body>
-    <script src="public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
     <div class="container content-container">
       <div class="well">
         <header>Algorithmia Topic Analysis</header>
@@ -97,9 +97,9 @@ Algorithmia.client(apiKey).algo("/nlp/LDA").pipe([strings, numTopics]).then(func
         fill: white;
       }
       </style>
-      <script src="public/js/d3.min.js" type="text/javascript"></script>
-      <script src="public/js/algorithmia.d3.js" type="text/javascript"></script>
-      <script src="public/js/main.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/d3.min.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
     </div>
   </body>
 </html>

--- a/JavaScript/lda2/index.html
+++ b/JavaScript/lda2/index.html
@@ -24,17 +24,17 @@
 
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.js" type="text/javascript"></script>
   </head>
   <body>
-    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/common.cat.js" type="text/javascript"></script>
     <div class="container content-container">
       <div class="well">
         <header>Algorithmia Topic Analysis</header>
@@ -97,9 +97,9 @@ Algorithmia.client(apiKey).algo("/nlp/LDA").pipe([strings, numTopics]).then(func
         fill: white;
       }
       </style>
-      <script src="<%= demo_root %>/public/js/d3.min.js" type="text/javascript"></script>
-      <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
-      <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/d3.min.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/main.js" type="text/javascript"></script>
     </div>
   </body>
 </html>

--- a/JavaScript/othello/index.html
+++ b/JavaScript/othello/index.html
@@ -24,14 +24,14 @@
 
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="public/css/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <script src="public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
   </head>
   <body>
     <div class="container content-container">
@@ -105,8 +105,8 @@ Algorithmia.client(apiKey).algo("/kenny/Othello").pipe([board, player]).then(fun
         </div>
       </div>
     </div>
-    <script src="public/js/common.cat.js" type="text/javascript"></script>
-    <script src="public/js/core.cat.min.js" type="text/javascript"></script>
-    <script src="public/js/main.js" charset="utf-8" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/core.cat.min.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/main.js" charset="utf-8" type="text/javascript"></script>
   </body>
 </html>

--- a/JavaScript/othello/index.html
+++ b/JavaScript/othello/index.html
@@ -24,14 +24,14 @@
 
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.js" type="text/javascript"></script>
   </head>
   <body>
     <div class="container content-container">
@@ -105,8 +105,8 @@ Algorithmia.client(apiKey).algo("/kenny/Othello").pipe([board, player]).then(fun
         </div>
       </div>
     </div>
-    <script src="<%= demo_root %>/public/js/common.cat.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/core.cat.min.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/main.js" charset="utf-8" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/common.cat.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/core.cat.min.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/main.js" charset="utf-8" type="text/javascript"></script>
   </body>
 </html>

--- a/JavaScript/othello/public/js/main.js
+++ b/JavaScript/othello/public/js/main.js
@@ -82,7 +82,7 @@
       }
     };
     $scope.pieceImg = function(player) {
-      return "public/images/circle" + player + ".png";
+      return "othello/public/images/circle" + player + ".png";
     };
     otherPlayer = function() {
       return ($scope.player % 2) + 1;

--- a/JavaScript/pathplan/index.html
+++ b/JavaScript/pathplan/index.html
@@ -25,17 +25,17 @@
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
 
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="public/css/font-awesome/css/font-awesome.min.css" type="text/css">
-    <link rel="stylesheet" href="public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css" type="text/css">
+    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <script src="public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
   </head>
   <body>
-    <script src="public/js/common.cat.min.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/common.cat.min.js" type="text/javascript"></script>
     <div class="container content-container">
       <div class="well">
         <header>Algorithmia Path Planning</header>
@@ -90,9 +90,9 @@ Algorithmia.client(apiKey).algo("/kenny/MazeGen").pipe(searchString).then(functi
           <div class="tab-pane debug" id="path-out">...</div>
         </div>
       </div>
-      <script src="public/js/d3.min.js" type="text/javascript"></script>
-      <script src="public/js/algorithmia.d3.js" type="text/javascript"></script>
-      <script src="public/js/main.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/d3.min.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+      <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
     </div>
   </body>
 </html>

--- a/JavaScript/pathplan/index.html
+++ b/JavaScript/pathplan/index.html
@@ -25,17 +25,17 @@
     <meta name="robots" content="index,follow">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.75">
 
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
 
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/font-awesome/css/font-awesome.min.css" type="text/css">
-    <link rel="stylesheet" href="<%= demo_root %>/public/css/core.cat.min.css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/font-awesome/css/font-awesome.min.css" type="text/css">
+    <link rel="stylesheet" href="<%= slug %>/public/css/core.cat.min.css">
 
     <!--[if lt IE 9]><script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <script src="<%= demo_root %>/public/js/algorithmia.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.js" type="text/javascript"></script>
   </head>
   <body>
-    <script src="<%= demo_root %>/public/js/common.cat.min.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/common.cat.min.js" type="text/javascript"></script>
     <div class="container content-container">
       <div class="well">
         <header>Algorithmia Path Planning</header>
@@ -90,9 +90,9 @@ Algorithmia.client(apiKey).algo("/kenny/MazeGen").pipe(searchString).then(functi
           <div class="tab-pane debug" id="path-out">...</div>
         </div>
       </div>
-      <script src="<%= demo_root %>/public/js/d3.min.js" type="text/javascript"></script>
-      <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
-      <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/d3.min.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+      <script src="<%= slug %>/public/js/main.js" type="text/javascript"></script>
     </div>
   </body>
 </html>

--- a/JavaScript/places-demo/index.html
+++ b/JavaScript/places-demo/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 	<title>Deep Learning to Classify Places, Locations, and Scenes in Images – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/classify-places/" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
 	<meta name="description" content="Use deep learning algorithms to identify places in images with the Places365 Classifier microservice, trained on 1.8 million images to recognize 365 scenes">
 	<meta name="robots" content="index,follow">
 
@@ -50,19 +50,19 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/alley_lg.jpg')"><img src="public/images/alley_sm.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/alley_lg.jpg')"><img src="<%= demo_root %>/public/images/alley_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/dock_lg.jpg')"><img src="public/images/dock_sm.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/dock_lg.jpg')"><img src="<%= demo_root %>/public/images/dock_sm.jpg"></a>
 							</div> 
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/canyon_lg.jpg')"><img src="public/images/canyon_sm.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/canyon_lg.jpg')"><img src="<%= demo_root %>/public/images/canyon_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/skyscraper_lg.jpg')"><img src="public/images/skyscraper_sm.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/skyscraper_lg.jpg')"><img src="<%= demo_root %>/public/images/skyscraper_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/airplane_lg.jpg')"><img src="public/images/airplane_sm.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/airplane_lg.jpg')"><img src="<%= demo_root %>/public/images/airplane_sm.jpg"></a>
 							</div>
 						</div>
 					</div>
@@ -160,8 +160,8 @@ algo = client.algo(<span class="hljs-string">'deeplearning/Places365Classifier/0
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/dropzone.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/places-demo/index.html
+++ b/JavaScript/places-demo/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 	<title>Deep Learning to Classify Places, Locations, and Scenes in Images – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>" />
 	<meta name="description" content="Use deep learning algorithms to identify places in images with the Places365 Classifier microservice, trained on 1.8 million images to recognize 365 scenes">
 	<meta name="robots" content="index,follow">
 
@@ -50,19 +50,19 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/alley_lg.jpg')"><img src="<%= demo_root %>/public/images/alley_sm.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/alley_lg.jpg')"><img src="<%= slug %>/public/images/alley_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/dock_lg.jpg')"><img src="<%= demo_root %>/public/images/dock_sm.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/dock_lg.jpg')"><img src="<%= slug %>/public/images/dock_sm.jpg"></a>
 							</div> 
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/canyon_lg.jpg')"><img src="<%= demo_root %>/public/images/canyon_sm.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/canyon_lg.jpg')"><img src="<%= slug %>/public/images/canyon_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/skyscraper_lg.jpg')"><img src="<%= demo_root %>/public/images/skyscraper_sm.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/skyscraper_lg.jpg')"><img src="<%= slug %>/public/images/skyscraper_sm.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/airplane_lg.jpg')"><img src="<%= demo_root %>/public/images/airplane_sm.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/airplane_lg.jpg')"><img src="<%= slug %>/public/images/airplane_sm.jpg"></a>
 							</div>
 						</div>
 					</div>
@@ -160,8 +160,8 @@ algo = client.algo(<span class="hljs-string">'deeplearning/Places365Classifier/0
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/site-mapper/index.html
+++ b/JavaScript/site-mapper/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
   <title>Site Mapper - Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/sitemap/" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
 	<meta name="description" content="Crawl a website, rank the pages, and extract content with Algorithmia's microservices.">
 
 	<!-- FB -->
@@ -197,9 +197,9 @@ algo = client.algo(<span class="hljs-string">'web/GetLinks/0.1.5'</span>)
 
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/d3.min.js"></script>
-  <script src="public/js/algorithmia.d3.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/d3.min.js"></script>
+  <script src="<%= demo_root %>/public/js/algorithmia.d3.js"></script>
 
   <%= footer %>

--- a/JavaScript/site-mapper/index.html
+++ b/JavaScript/site-mapper/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
   <title>Site Mapper - Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>" />
 	<meta name="description" content="Crawl a website, rank the pages, and extract content with Algorithmia's microservices.">
 
 	<!-- FB -->
@@ -197,9 +197,9 @@ algo = client.algo(<span class="hljs-string">'web/GetLinks/0.1.5'</span>)
 
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/d3.min.js"></script>
-  <script src="<%= demo_root %>/public/js/algorithmia.d3.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/d3.min.js"></script>
+  <script src="<%= slug %>/public/js/algorithmia.d3.js"></script>
 
   <%= footer %>

--- a/JavaScript/social-image-rec-pixabay/index.html
+++ b/JavaScript/social-image-rec-pixabay/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>Social Media Image Recommender - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/social-image-rec-pixabay/">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
 <meta name="description" content="Get image recommendations based on text content"/>
 <meta name="robots" content="index,follow">
 
@@ -209,9 +209,9 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/dropzone.js"></script>
-  <script src="public/js/pixabay-widget-algorithmia.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
+  <script src="<%= demo_root %>/public/js/pixabay-widget-algorithmia.js"></script>
 
   <%= footer %>

--- a/JavaScript/social-image-rec-pixabay/index.html
+++ b/JavaScript/social-image-rec-pixabay/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>Social Media Image Recommender - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>">
 <meta name="description" content="Get image recommendations based on text content"/>
 <meta name="robots" content="index,follow">
 
@@ -209,9 +209,9 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
-  <script src="<%= demo_root %>/public/js/pixabay-widget-algorithmia.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/dropzone.js"></script>
+  <script src="<%= slug %>/public/js/pixabay-widget-algorithmia.js"></script>
 
   <%= footer %>

--- a/JavaScript/social-image-rec/index.html
+++ b/JavaScript/social-image-rec/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>Social Media Image Recommender - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>">
 <meta name="description" content="Get image recommendations based on text content"/>
 <meta name="robots" content="index,follow">
 
@@ -195,8 +195,8 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/social-image-rec/index.html
+++ b/JavaScript/social-image-rec/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>Social Media Image Recommender - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/social-image-rec/">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
 <meta name="description" content="Get image recommendations based on text content"/>
 <meta name="robots" content="index,follow">
 
@@ -195,8 +195,8 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/dropzone.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/time-series/index.html
+++ b/JavaScript/time-series/index.html
@@ -3,7 +3,7 @@
 	<%= segment_script %>
 
 	<title>Time Series – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/timeseries/" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
 	<meta name="description" content="Track economic development with open data and predictive algorithms">
 	<meta name="robots" content="index,follow">
 
@@ -174,7 +174,7 @@ Algorithmia.client(<span class="hljs-string"><span class="hljs-string">"YOUR_API
 	</script>
 
     <!-- JS -->
-	<script src="public/js/d3.min.js"></script>
-	<script src="public/js/algorithmia.d3.js"></script>
+	<script src="<%= demo_root %>/public/js/d3.min.js"></script>
+	<script src="<%= demo_root %>/public/js/algorithmia.d3.js"></script>
 
 	<%= footer %>

--- a/JavaScript/time-series/index.html
+++ b/JavaScript/time-series/index.html
@@ -3,7 +3,7 @@
 	<%= segment_script %>
 
 	<title>Time Series – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>" />
 	<meta name="description" content="Track economic development with open data and predictive algorithms">
 	<meta name="robots" content="index,follow">
 
@@ -174,7 +174,7 @@ Algorithmia.client(<span class="hljs-string"><span class="hljs-string">"YOUR_API
 	</script>
 
     <!-- JS -->
-	<script src="<%= demo_root %>/public/js/d3.min.js"></script>
-	<script src="<%= demo_root %>/public/js/algorithmia.d3.js"></script>
+	<script src="<%= slug %>/public/js/d3.min.js"></script>
+	<script src="<%= slug %>/public/js/algorithmia.d3.js"></script>
 
 	<%= footer %>

--- a/JavaScript/twitter-ngram/index.html
+++ b/JavaScript/twitter-ngram/index.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <title>Twitter Ngram Demo</title>
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
-    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/algo.min.css">
-    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/bootstrap3.min.css"å>
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="stylesheet" media="screen" href="<%= slug %>/public/css/algo.min.css">
+    <link rel="stylesheet" media="screen" href="<%= slug %>/public/css/bootstrap3.min.css"å>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="https://netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.min.js"></script>
-    <script src="<%= demo_root %>/public/js/algorithmia.js"></script>
-    <script src="<%= demo_root %>/public/js/d3.min.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/algorithmia.data.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.js"></script>
+    <script src="<%= slug %>/public/js/d3.min.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.data.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/main.js" type="text/javascript"></script>
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
     <style>
 

--- a/JavaScript/twitter-ngram/index.html
+++ b/JavaScript/twitter-ngram/index.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <title>Twitter Ngram Demo</title>
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
-    <link rel="stylesheet" media="screen" href="public/css/algo.min.css">
-    <link rel="stylesheet" media="screen" href="public/css/bootstrap3.min.css"å>
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/algo.min.css">
+    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/bootstrap3.min.css"å>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="https://netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.min.js"></script>
-    <script src="public/js/algorithmia.js"></script>
-    <script src="public/js/d3.min.js" type="text/javascript"></script>
-    <script src="public/js/algorithmia.d3.js" type="text/javascript"></script>
-    <script src="public/js/algorithmia.data.js" type="text/javascript"></script>
-    <script src="public/js/main.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.js"></script>
+    <script src="<%= demo_root %>/public/js/d3.min.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.data.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
     <style>
 

--- a/JavaScript/valentines/index.html
+++ b/JavaScript/valentines/index.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <title>Algorithmia V-day Demo</title>
-    <link rel="shortcut icon" href="public/images/favicon-bw.png" type="image/png">
-    <link rel="stylesheet" media="screen" href="public/css/algo.min.css" type="text/css">
-    <link rel="stylesheet" media="screen" href="public/css/bootstrap3.min.css">
+    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/algo.min.css" type="text/css">
+    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/bootstrap3.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="https://netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.min.js"></script>
-    <script src="public/js/algorithmia.js"></script>
-    <script src="public/js/d3.min.js" type="text/javascript"></script>
-    <script src="public/js/algorithmia.d3.js" type="text/javascript"></script>
-    <script src="public/js/algorithmia.data.js" type="text/javascript"></script>
-    <script src="public/js/main.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.js"></script>
+    <script src="<%= demo_root %>/public/js/d3.min.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/algorithmia.data.js" type="text/javascript"></script>
+    <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
     <style>
 

--- a/JavaScript/valentines/index.html
+++ b/JavaScript/valentines/index.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <title>Algorithmia V-day Demo</title>
-    <link rel="shortcut icon" href="<%= demo_root %>/public/images/favicon-bw.png" type="image/png">
-    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/algo.min.css" type="text/css">
-    <link rel="stylesheet" media="screen" href="<%= demo_root %>/public/css/bootstrap3.min.css">
+    <link rel="shortcut icon" href="<%= slug %>/public/images/favicon-bw.png" type="image/png">
+    <link rel="stylesheet" media="screen" href="<%= slug %>/public/css/algo.min.css" type="text/css">
+    <link rel="stylesheet" media="screen" href="<%= slug %>/public/css/bootstrap3.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="https://netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.min.js"></script>
-    <script src="<%= demo_root %>/public/js/algorithmia.js"></script>
-    <script src="<%= demo_root %>/public/js/d3.min.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/algorithmia.data.js" type="text/javascript"></script>
-    <script src="<%= demo_root %>/public/js/main.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.js"></script>
+    <script src="<%= slug %>/public/js/d3.min.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.d3.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/algorithmia.data.js" type="text/javascript"></script>
+    <script src="<%= slug %>/public/js/main.js" type="text/javascript"></script>
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
     <style>
 

--- a/JavaScript/video-metadata/index.html
+++ b/JavaScript/video-metadata/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>Video metadata extraction - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/video-metadata/">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
 <meta name="description" content="Video transformations and data extraction"/>
 <meta name="robots" content="index,follow">
 
@@ -29,8 +29,8 @@
 <meta itemprop="description" content="Use machine learning to extract information from your videos">
 
 <!-- CSS -->
-<link rel="stylesheet" href="public/css/font.knightlab.css">
-<link title="timeline-styles" rel="stylesheet" href="public/css/timeline.css">
+<link rel="stylesheet" href="<%= demo_root %>/public/css/font.knightlab.css">
+<link title="timeline-styles" rel="stylesheet" href="<%= demo_root %>/public/css/timeline.css">
 
 <%= header_end %>
 
@@ -46,40 +46,40 @@
           <h3>1. CHOOSE A VIDEO</h3>
           <div class="row whitespace sample-videos">
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('massage')"><img src="public/images/massage.png" alt="massage" id="video-thumb-massage" class="video-thumb"></a>
+              <a onclick="selectVideo('massage')"><img src="<%= demo_root %>/public/images/massage.png" alt="massage" id="video-thumb-massage" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('india1643')"><img src="public/images/india1643.png" alt="india1643" id="video-thumb-india1643" class="video-thumb"></a>
+              <a onclick="selectVideo('india1643')"><img src="<%= demo_root %>/public/images/india1643.png" alt="india1643" id="video-thumb-india1643" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('city730')"><img src="public/images/city730.png" alt="city730" id="video-thumb-city730" class="video-thumb"></a>
-            </div>
-            <!--<div class="col-xs-6 col-sm-3 sample-image">-->
-              <!--<a onclick="selectVideo('india8698')"><img src="public/images/india8698.png" alt="india8698" id="video-thumb-india8698" class="video-thumb"></a>-->
-            <!--</div>-->
-            <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('dance4428')"><img src="public/images/dance4428.png" alt="dance4428" id="video-thumb-dance4428" class="video-thumb"></a>
+              <a onclick="selectVideo('city730')"><img src="<%= demo_root %>/public/images/city730.png" alt="city730" id="video-thumb-city730" class="video-thumb"></a>
             </div>
             <!--<div class="col-xs-6 col-sm-3 sample-image">-->
-              <!--<a onclick="selectVideo('wiffle')"><img src="public/images/wiffle.png" alt="wiffle" id="video-thumb-wiffle" class="video-thumb"></a>-->
-            <!--</div>-->
-            <!--<div class="col-xs-6 col-sm-3 sample-image">-->
-              <!--<a onclick="selectVideo('motorcycle')"><img src="public/images/motorcycle.png" alt="motorcycle" id="video-thumb-motorcycle" class="video-thumb"></a>-->
+              <!--<a onclick="selectVideo('india8698')"><img src="<%= demo_root %>/public/images/india8698.png" alt="india8698" id="video-thumb-india8698" class="video-thumb"></a>-->
             <!--</div>-->
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('slapping64')"><img src="public/images/slapping64.png" alt="slapping64" id="video-thumb-slapping64" class="video-thumb"></a>
+              <a onclick="selectVideo('dance4428')"><img src="<%= demo_root %>/public/images/dance4428.png" alt="dance4428" id="video-thumb-dance4428" class="video-thumb"></a>
             </div>
             <!--<div class="col-xs-6 col-sm-3 sample-image">-->
-              <!--<a onclick="selectVideo('training1194')"><img src="public/images/training1194.png" alt="training1194" id="video-thumb-training1194" class="video-thumb"></a>-->
+              <!--<a onclick="selectVideo('wiffle')"><img src="<%= demo_root %>/public/images/wiffle.png" alt="wiffle" id="video-thumb-wiffle" class="video-thumb"></a>-->
+            <!--</div>-->
+            <!--<div class="col-xs-6 col-sm-3 sample-image">-->
+              <!--<a onclick="selectVideo('motorcycle')"><img src="<%= demo_root %>/public/images/motorcycle.png" alt="motorcycle" id="video-thumb-motorcycle" class="video-thumb"></a>-->
             <!--</div>-->
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('woman87')"><img src="public/images/woman87.png" alt="woman87" id="video-thumb-woman87" class="video-thumb"></a>
+              <a onclick="selectVideo('slapping64')"><img src="<%= demo_root %>/public/images/slapping64.png" alt="slapping64" id="video-thumb-slapping64" class="video-thumb"></a>
+            </div>
+            <!--<div class="col-xs-6 col-sm-3 sample-image">-->
+              <!--<a onclick="selectVideo('training1194')"><img src="<%= demo_root %>/public/images/training1194.png" alt="training1194" id="video-thumb-training1194" class="video-thumb"></a>-->
+            <!--</div>-->
+            <div class="col-xs-6 col-sm-3 sample-image">
+              <a onclick="selectVideo('woman87')"><img src="<%= demo_root %>/public/images/woman87.png" alt="woman87" id="video-thumb-woman87" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('crowd6582')"><img src="public/images/crowd6582.png" alt="crowd6582" id="video-thumb-crowd6582" class="video-thumb"></a>
+              <a onclick="selectVideo('crowd6582')"><img src="<%= demo_root %>/public/images/crowd6582.png" alt="crowd6582" id="video-thumb-crowd6582" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('busstation6094')"><img src="public/images/busstation6094.png" alt="busstation6094" id="video-thumb-busstation6094" class="video-thumb"></a>
+              <a onclick="selectVideo('busstation6094')"><img src="<%= demo_root %>/public/images/busstation6094.png" alt="busstation6094" id="video-thumb-busstation6094" class="video-thumb"></a>
             </div>
           </div>
           <h3>2. CHOOSE AN ALGORITHM</h3>
@@ -217,9 +217,9 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/dropzone.js"></script>
-  <script src="public/js/timeline-min.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
+  <script src="<%= demo_root %>/public/js/timeline-min.js"></script>
 
   <%= footer %>

--- a/JavaScript/video-metadata/index.html
+++ b/JavaScript/video-metadata/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>Video metadata extraction - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>">
 <meta name="description" content="Video transformations and data extraction"/>
 <meta name="robots" content="index,follow">
 
@@ -29,8 +29,8 @@
 <meta itemprop="description" content="Use machine learning to extract information from your videos">
 
 <!-- CSS -->
-<link rel="stylesheet" href="<%= demo_root %>/public/css/font.knightlab.css">
-<link title="timeline-styles" rel="stylesheet" href="<%= demo_root %>/public/css/timeline.css">
+<link rel="stylesheet" href="<%= slug %>/public/css/font.knightlab.css">
+<link title="timeline-styles" rel="stylesheet" href="<%= slug %>/public/css/timeline.css">
 
 <%= header_end %>
 
@@ -46,40 +46,40 @@
           <h3>1. CHOOSE A VIDEO</h3>
           <div class="row whitespace sample-videos">
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('massage')"><img src="<%= demo_root %>/public/images/massage.png" alt="massage" id="video-thumb-massage" class="video-thumb"></a>
+              <a onclick="selectVideo('massage')"><img src="<%= slug %>/public/images/massage.png" alt="massage" id="video-thumb-massage" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('india1643')"><img src="<%= demo_root %>/public/images/india1643.png" alt="india1643" id="video-thumb-india1643" class="video-thumb"></a>
+              <a onclick="selectVideo('india1643')"><img src="<%= slug %>/public/images/india1643.png" alt="india1643" id="video-thumb-india1643" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('city730')"><img src="<%= demo_root %>/public/images/city730.png" alt="city730" id="video-thumb-city730" class="video-thumb"></a>
-            </div>
-            <!--<div class="col-xs-6 col-sm-3 sample-image">-->
-              <!--<a onclick="selectVideo('india8698')"><img src="<%= demo_root %>/public/images/india8698.png" alt="india8698" id="video-thumb-india8698" class="video-thumb"></a>-->
-            <!--</div>-->
-            <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('dance4428')"><img src="<%= demo_root %>/public/images/dance4428.png" alt="dance4428" id="video-thumb-dance4428" class="video-thumb"></a>
+              <a onclick="selectVideo('city730')"><img src="<%= slug %>/public/images/city730.png" alt="city730" id="video-thumb-city730" class="video-thumb"></a>
             </div>
             <!--<div class="col-xs-6 col-sm-3 sample-image">-->
-              <!--<a onclick="selectVideo('wiffle')"><img src="<%= demo_root %>/public/images/wiffle.png" alt="wiffle" id="video-thumb-wiffle" class="video-thumb"></a>-->
-            <!--</div>-->
-            <!--<div class="col-xs-6 col-sm-3 sample-image">-->
-              <!--<a onclick="selectVideo('motorcycle')"><img src="<%= demo_root %>/public/images/motorcycle.png" alt="motorcycle" id="video-thumb-motorcycle" class="video-thumb"></a>-->
+              <!--<a onclick="selectVideo('india8698')"><img src="<%= slug %>/public/images/india8698.png" alt="india8698" id="video-thumb-india8698" class="video-thumb"></a>-->
             <!--</div>-->
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('slapping64')"><img src="<%= demo_root %>/public/images/slapping64.png" alt="slapping64" id="video-thumb-slapping64" class="video-thumb"></a>
+              <a onclick="selectVideo('dance4428')"><img src="<%= slug %>/public/images/dance4428.png" alt="dance4428" id="video-thumb-dance4428" class="video-thumb"></a>
             </div>
             <!--<div class="col-xs-6 col-sm-3 sample-image">-->
-              <!--<a onclick="selectVideo('training1194')"><img src="<%= demo_root %>/public/images/training1194.png" alt="training1194" id="video-thumb-training1194" class="video-thumb"></a>-->
+              <!--<a onclick="selectVideo('wiffle')"><img src="<%= slug %>/public/images/wiffle.png" alt="wiffle" id="video-thumb-wiffle" class="video-thumb"></a>-->
+            <!--</div>-->
+            <!--<div class="col-xs-6 col-sm-3 sample-image">-->
+              <!--<a onclick="selectVideo('motorcycle')"><img src="<%= slug %>/public/images/motorcycle.png" alt="motorcycle" id="video-thumb-motorcycle" class="video-thumb"></a>-->
             <!--</div>-->
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('woman87')"><img src="<%= demo_root %>/public/images/woman87.png" alt="woman87" id="video-thumb-woman87" class="video-thumb"></a>
+              <a onclick="selectVideo('slapping64')"><img src="<%= slug %>/public/images/slapping64.png" alt="slapping64" id="video-thumb-slapping64" class="video-thumb"></a>
+            </div>
+            <!--<div class="col-xs-6 col-sm-3 sample-image">-->
+              <!--<a onclick="selectVideo('training1194')"><img src="<%= slug %>/public/images/training1194.png" alt="training1194" id="video-thumb-training1194" class="video-thumb"></a>-->
+            <!--</div>-->
+            <div class="col-xs-6 col-sm-3 sample-image">
+              <a onclick="selectVideo('woman87')"><img src="<%= slug %>/public/images/woman87.png" alt="woman87" id="video-thumb-woman87" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('crowd6582')"><img src="<%= demo_root %>/public/images/crowd6582.png" alt="crowd6582" id="video-thumb-crowd6582" class="video-thumb"></a>
+              <a onclick="selectVideo('crowd6582')"><img src="<%= slug %>/public/images/crowd6582.png" alt="crowd6582" id="video-thumb-crowd6582" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('busstation6094')"><img src="<%= demo_root %>/public/images/busstation6094.png" alt="busstation6094" id="video-thumb-busstation6094" class="video-thumb"></a>
+              <a onclick="selectVideo('busstation6094')"><img src="<%= slug %>/public/images/busstation6094.png" alt="busstation6094" id="video-thumb-busstation6094" class="video-thumb"></a>
             </div>
           </div>
           <h3>2. CHOOSE AN ALGORITHM</h3>
@@ -217,9 +217,9 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
-  <script src="<%= demo_root %>/public/js/timeline-min.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/dropzone.js"></script>
+  <script src="<%= slug %>/public/js/timeline-min.js"></script>
 
   <%= footer %>

--- a/JavaScript/video-search/index.html
+++ b/JavaScript/video-search/index.html
@@ -3,7 +3,7 @@
 	<%= segment_script %>
 
 	<title>Search Unstructured Video – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>" />
 	<meta name="description" content="Automatically search unstructured videos using Algorithmia video tagging.">
 
 	<!-- FB -->
@@ -119,7 +119,7 @@
 							<p class="lg item-title">1. Download video</p>
 						</div>
 						<div class="col-sm-3">
-							<img class="" src="<%= demo_root %>/public/images/step01.png">
+							<img class="" src="<%= slug %>/public/images/step01.png">
 						</div>
 						<div class="col-sm-9 col-md-6">
 							<p>The video file is downloaded from YouTube, Dropbox, S3, or another source, and its file format is examined before proceeding.</p>
@@ -134,7 +134,7 @@
 							<p>The <a href="https://algorithmia.com/algorithms/media/VideoMetadataExtraction">Video Metadata Extraction</a> algorithm splits the video into frames, then processes them in batches.</p>
 						</div>
 						<div class="col-sm-3">
-							<img src="<%= demo_root %>/public/images/step02.png">
+							<img src="<%= slug %>/public/images/step02.png">
 						</div>
 					</li>
 					<li class="row">
@@ -142,7 +142,7 @@
 							<p class="lg item-title">3. Auto-generate frame tags</p>
 						</div>
 						<div class="col-sm-3">
-							<img src="<%= demo_root %>/public/images/step03.png">
+							<img src="<%= slug %>/public/images/step03.png">
 						</div>
 						<div class="col-sm-9 col-md-6">
 							<p>Tags and annotations describing each frame are generated using <a href="https://algorithmia.com/algorithms/deeplearning/InceptionNet">InceptionNet</a> and other image classification/extraction algorithms.</p>
@@ -157,7 +157,7 @@
 							<p>After the video is processed, timestamps are assigned to each extracted tag, allowing users to search across one or many videos for specific tags.</p>
 						</div>
 						<div class="col-sm-3">
-							<img src="<%= demo_root %>/public/images/step04.png">
+							<img src="<%= slug %>/public/images/step04.png">
 						</div>
 					</li>
 				</ul>
@@ -201,7 +201,7 @@ algo = client.algo(<span class="hljs-string">'media/VideoMetadataExtraction/0.1.
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
 
   <%= footer %>

--- a/JavaScript/video-search/index.html
+++ b/JavaScript/video-search/index.html
@@ -3,7 +3,7 @@
 	<%= segment_script %>
 
 	<title>Search Unstructured Video – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/video-search/" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
 	<meta name="description" content="Automatically search unstructured videos using Algorithmia video tagging.">
 
 	<!-- FB -->
@@ -119,7 +119,7 @@
 							<p class="lg item-title">1. Download video</p>
 						</div>
 						<div class="col-sm-3">
-							<img class="" src="public/images/step01.png">
+							<img class="" src="<%= demo_root %>/public/images/step01.png">
 						</div>
 						<div class="col-sm-9 col-md-6">
 							<p>The video file is downloaded from YouTube, Dropbox, S3, or another source, and its file format is examined before proceeding.</p>
@@ -134,7 +134,7 @@
 							<p>The <a href="https://algorithmia.com/algorithms/media/VideoMetadataExtraction">Video Metadata Extraction</a> algorithm splits the video into frames, then processes them in batches.</p>
 						</div>
 						<div class="col-sm-3">
-							<img src="public/images/step02.png">
+							<img src="<%= demo_root %>/public/images/step02.png">
 						</div>
 					</li>
 					<li class="row">
@@ -142,7 +142,7 @@
 							<p class="lg item-title">3. Auto-generate frame tags</p>
 						</div>
 						<div class="col-sm-3">
-							<img src="public/images/step03.png">
+							<img src="<%= demo_root %>/public/images/step03.png">
 						</div>
 						<div class="col-sm-9 col-md-6">
 							<p>Tags and annotations describing each frame are generated using <a href="https://algorithmia.com/algorithms/deeplearning/InceptionNet">InceptionNet</a> and other image classification/extraction algorithms.</p>
@@ -157,7 +157,7 @@
 							<p>After the video is processed, timestamps are assigned to each extracted tag, allowing users to search across one or many videos for specific tags.</p>
 						</div>
 						<div class="col-sm-3">
-							<img src="public/images/step04.png">
+							<img src="<%= demo_root %>/public/images/step04.png">
 						</div>
 					</li>
 				</ul>
@@ -201,7 +201,7 @@ algo = client.algo(<span class="hljs-string">'media/VideoMetadataExtraction/0.1.
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
 
   <%= footer %>

--- a/JavaScript/video-toolbox/index.html
+++ b/JavaScript/video-toolbox/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>Video transformations - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/video-toolbox/">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
 <meta name="description" content="Video transformations, powered by Machine Learning"/>
 <meta name="robots" content="index,follow">
 
@@ -42,16 +42,16 @@
           <h3>1. CHOOSE A VIDEO</h3>
           <div class="row whitespace sample-videos">
             <div class="col-xs-6 col-sm-3">
-              <a onclick="selectVideo('beach')"><img src="public/images/beach.png" alt="beach" id="video-thumb-beach" class="video-thumb"></a>
+              <a onclick="selectVideo('beach')"><img src="<%= demo_root %>/public/images/beach.png" alt="beach" id="video-thumb-beach" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('office')"><img src="public/images/office.png" alt="office" id="video-thumb-office" class="video-thumb"></a>
+              <a onclick="selectVideo('office')"><img src="<%= demo_root %>/public/images/office.png" alt="office" id="video-thumb-office" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('dog')"><img src="public/images/dog.png" alt="dog" id="video-thumb-dog" class="video-thumb"></a>
+              <a onclick="selectVideo('dog')"><img src="<%= demo_root %>/public/images/dog.png" alt="dog" id="video-thumb-dog" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('keyboard')"><img src="public/images/keyboard.png" alt="keyboard" id="video-thumb-keyboard" class="video-thumb"></a>
+              <a onclick="selectVideo('keyboard')"><img src="<%= demo_root %>/public/images/keyboard.png" alt="keyboard" id="video-thumb-keyboard" class="video-thumb"></a>
             </div>
           </div>
           <h3>2. CHOOSE A MODIFIER</h3>
@@ -186,8 +186,8 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
-  <script src="public/js/dropzone.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/video-toolbox/index.html
+++ b/JavaScript/video-toolbox/index.html
@@ -3,7 +3,7 @@
 <%= segment_script %>
 
 <title>Video transformations - Algorithmia</title>
-<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>">
+<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>">
 <meta name="description" content="Video transformations, powered by Machine Learning"/>
 <meta name="robots" content="index,follow">
 
@@ -42,16 +42,16 @@
           <h3>1. CHOOSE A VIDEO</h3>
           <div class="row whitespace sample-videos">
             <div class="col-xs-6 col-sm-3">
-              <a onclick="selectVideo('beach')"><img src="<%= demo_root %>/public/images/beach.png" alt="beach" id="video-thumb-beach" class="video-thumb"></a>
+              <a onclick="selectVideo('beach')"><img src="<%= slug %>/public/images/beach.png" alt="beach" id="video-thumb-beach" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('office')"><img src="<%= demo_root %>/public/images/office.png" alt="office" id="video-thumb-office" class="video-thumb"></a>
+              <a onclick="selectVideo('office')"><img src="<%= slug %>/public/images/office.png" alt="office" id="video-thumb-office" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('dog')"><img src="<%= demo_root %>/public/images/dog.png" alt="dog" id="video-thumb-dog" class="video-thumb"></a>
+              <a onclick="selectVideo('dog')"><img src="<%= slug %>/public/images/dog.png" alt="dog" id="video-thumb-dog" class="video-thumb"></a>
             </div>
             <div class="col-xs-6 col-sm-3 sample-image">
-              <a onclick="selectVideo('keyboard')"><img src="<%= demo_root %>/public/images/keyboard.png" alt="keyboard" id="video-thumb-keyboard" class="video-thumb"></a>
+              <a onclick="selectVideo('keyboard')"><img src="<%= slug %>/public/images/keyboard.png" alt="keyboard" id="video-thumb-keyboard" class="video-thumb"></a>
             </div>
           </div>
           <h3>2. CHOOSE A MODIFIER</h3>
@@ -186,8 +186,8 @@ print algo.pipe(input)
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
-  <script src="<%= demo_root %>/public/js/dropzone.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/dropzone.js"></script>
 
   <%= footer %>

--- a/JavaScript/web-page-inspector/index.html
+++ b/JavaScript/web-page-inspector/index.html
@@ -3,7 +3,7 @@
 	<%= segment_script %>
 
 	<title>Extract Structured Data From Web Sites – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= slug %>" />
 	<meta name="description" content="An API to instantly retrieve clean, structured data from any URL, returned as useful JSON.">
 
 	<!-- FB -->
@@ -53,16 +53,16 @@
 						<h4 class="dark whitespace-sm">Or, try these sample articles:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-3 col-sm-2 sample-image">
-								<a onclick="analyzeUrl('http://thenewstack.io/algorithmia-new-algorithm-economy/')"><img src="<%= demo_root %>/public/images/newstack.png"></a>
+								<a onclick="analyzeUrl('http://thenewstack.io/algorithmia-new-algorithm-economy/')"><img src="<%= slug %>/public/images/newstack.png"></a>
 							</div>
 							<div class="col-xs-3 col-sm-2 sample-image">
-								<a onclick="analyzeUrl('https://medium.com/emergent-future/machine-learning-trends-and-the-future-of-artificial-intelligence-2016-15c15cd6c129#.7vvstzebt')"><img src="<%= demo_root %>/public/images/machines.jpg"></a>
+								<a onclick="analyzeUrl('https://medium.com/emergent-future/machine-learning-trends-and-the-future-of-artificial-intelligence-2016-15c15cd6c129#.7vvstzebt')"><img src="<%= slug %>/public/images/machines.jpg"></a>
 							</div>
 							<div class="col-xs-3 col-sm-2 sample-image">
-								<a onclick="analyzeUrl('http://blog.algorithmia.com/predictive-algorithms-track-real-time-health-trends/')"><img src="<%= demo_root %>/public/images/predictive.jpg"></a>
+								<a onclick="analyzeUrl('http://blog.algorithmia.com/predictive-algorithms-track-real-time-health-trends/')"><img src="<%= slug %>/public/images/predictive.jpg"></a>
 							</div>
 							<div class="col-xs-3 col-sm-2 sample-image">
-								<a onclick="analyzeUrl('http://www.wired.com/2014/08/algorithmia/')"><img src="<%= demo_root %>/public/images/wired.jpg"></a>
+								<a onclick="analyzeUrl('http://www.wired.com/2014/08/algorithmia/')"><img src="<%= slug %>/public/images/wired.jpg"></a>
 							</div>
 						</div>
 					</div>
@@ -214,7 +214,7 @@ algo = client.algo(<span class="hljs-string">'outofstep/MegaAnalyzeURL/0.1.1'</s
   </section>
 
   <!-- JS -->
-  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
-  <script src="<%= demo_root %>/public/js/dots.js"></script>
+  <script src="<%= slug %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= slug %>/public/js/dots.js"></script>
 
   <%= footer %>

--- a/JavaScript/web-page-inspector/index.html
+++ b/JavaScript/web-page-inspector/index.html
@@ -3,7 +3,7 @@
 	<%= segment_script %>
 
 	<title>Extract Structured Data From Web Sites – Algorithmia</title>
-	<link rel="canonical" href="https://demos.algorithmia.com/web-page-inspector/" />
+	<link rel="canonical" href="https://demos.algorithmia.com/<%= demo_root %>" />
 	<meta name="description" content="An API to instantly retrieve clean, structured data from any URL, returned as useful JSON.">
 
 	<!-- FB -->
@@ -53,16 +53,16 @@
 						<h4 class="dark whitespace-sm">Or, try these sample articles:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-3 col-sm-2 sample-image">
-								<a onclick="analyzeUrl('http://thenewstack.io/algorithmia-new-algorithm-economy/')"><img src="public/images/newstack.png"></a>
+								<a onclick="analyzeUrl('http://thenewstack.io/algorithmia-new-algorithm-economy/')"><img src="<%= demo_root %>/public/images/newstack.png"></a>
 							</div>
 							<div class="col-xs-3 col-sm-2 sample-image">
-								<a onclick="analyzeUrl('https://medium.com/emergent-future/machine-learning-trends-and-the-future-of-artificial-intelligence-2016-15c15cd6c129#.7vvstzebt')"><img src="public/images/machines.jpg"></a>
+								<a onclick="analyzeUrl('https://medium.com/emergent-future/machine-learning-trends-and-the-future-of-artificial-intelligence-2016-15c15cd6c129#.7vvstzebt')"><img src="<%= demo_root %>/public/images/machines.jpg"></a>
 							</div>
 							<div class="col-xs-3 col-sm-2 sample-image">
-								<a onclick="analyzeUrl('http://blog.algorithmia.com/predictive-algorithms-track-real-time-health-trends/')"><img src="public/images/predictive.jpg"></a>
+								<a onclick="analyzeUrl('http://blog.algorithmia.com/predictive-algorithms-track-real-time-health-trends/')"><img src="<%= demo_root %>/public/images/predictive.jpg"></a>
 							</div>
 							<div class="col-xs-3 col-sm-2 sample-image">
-								<a onclick="analyzeUrl('http://www.wired.com/2014/08/algorithmia/')"><img src="public/images/wired.jpg"></a>
+								<a onclick="analyzeUrl('http://www.wired.com/2014/08/algorithmia/')"><img src="<%= demo_root %>/public/images/wired.jpg"></a>
 							</div>
 						</div>
 					</div>
@@ -214,7 +214,7 @@ algo = client.algo(<span class="hljs-string">'outofstep/MegaAnalyzeURL/0.1.1'</s
   </section>
 
   <!-- JS -->
-  <script src="public/js/TweenMax.min.js"></script>
-  <script src="public/js/dots.js"></script>
+  <script src="<%= demo_root %>/public/js/TweenMax.min.js"></script>
+  <script src="<%= demo_root %>/public/js/dots.js"></script>
 
   <%= footer %>


### PR DESCRIPTION
This PR makes changes for only one of the demos (colorization). I thought I'd get some feedback before updating the rest. Since we're now serving HTML from outside each demo's folder, the paths for `public/` assets had to be updated so CSS/JS/images don't 404.

You can see the 301 in action by hitting the static website url instead of the S3 object url:
```
curl -v http://algorithmia-synapse.s3-website-us-east-1.amazonaws.com/colorize-photos/
curl -v http://algorithmia-synapse.s3-website-us-east-1.amazonaws.com/colorize-photos/index.html
```

If you're curious what the bucket will look like, it's all inside the `algorithmia-synapse` bucket. This is an extra bucket I created while wiring up the Synapse CDN that I forgot to delete. I'll update this to the correct bucket before merging anything.

Note: if you try to actually use the colorizer, the client will receive a 401. This is expected as the request isn't coming from our domain.