### PR TITLE
Add session token to aws auth

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,7 @@ module.exports = function(grunt) {
       options: {
         accessKeyId: '<%= aws.key %>',
         secretAccessKey: '<%= aws.secret %>',
+        sessionToken: '<%= aws.session %>',
         bucket: 'demos.algorithmia.com',
         region: 'us-east-1',
         uploadConcurrency: 5,

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -39,7 +39,8 @@ You'll need to create `aws-keys.json` in the repo root:
 ```json
 {
   "key": "<ACCESS_KEY_ID>",
-  "secret": "<SECRET_ACCESS_KEY>"
+  "secret": "<SECRET_ACCESS_KEY>",
+  "session": "<SESSION_TOKEN>"
 }
 ```
 


### PR DESCRIPTION
A session token is required in order for us to be able to authenticate via the AWS CLI. Want to make sure that's documented in case someone else has to make a quick update in the future.