### PR TITLE
Ensure onclick handlers reference same urls used for images

### DIFF
--- a/JavaScript/deep-fashion/index.html
+++ b/JavaScript/deep-fashion/index.html
@@ -50,19 +50,19 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/blouse.jpg')"><img src="<%= slug %>/public/images/blouse.jpg"></a>
+								<a onclick="getTags('<%= slug %>/public/images/blouse.jpg')"><img src="<%= slug %>/public/images/blouse.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/suit.jpg')"><img src="<%= slug %>/public/images/suit.jpg"></a>
+								<a onclick="getTags('<%= slug %>/public/images/suit.jpg')"><img src="<%= slug %>/public/images/suit.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/tights.jpg')"><img src="<%= slug %>/public/images/tights.jpg"></a>
+								<a onclick="getTags('<%= slug %>/public/images/tights.jpg')"><img src="<%= slug %>/public/images/tights.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/buttondown.jpg')"><img src="<%= slug %>/public/images/buttondown.jpg"></a>
+								<a onclick="getTags('<%= slug %>/public/images/buttondown.jpg')"><img src="<%= slug %>/public/images/buttondown.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('https://s3.amazonaws.com/algorithmia-assets/deep-fashion/blazer.jpg')"><img src="<%= slug %>/public/images/blazer.jpg"></a>
+								<a onclick="getTags('<%= slug %>/public/images/blazer.jpg')"><img src="<%= slug %>/public/images/blazer.jpg"></a>
 							</div>
 						</div>
 					</div>

--- a/JavaScript/deep-fashion/public/js/main.js
+++ b/JavaScript/deep-fashion/public/js/main.js
@@ -21,7 +21,9 @@ $(document).ready(function() {
  */
 var getTags = function(url) {
   if(url) {
-    if(url.indexOf('http')==0) {$('#imgUrl').val(url);} //only display http URLs
+    $('#imgUrl').val(
+      url.startsWith('http') ? url : `${window.location.origin}/${url}`
+    );
   } else {
     url = $('#imgUrl').val();
   }

--- a/JavaScript/image-tagger/index.html
+++ b/JavaScript/image-tagger/index.html
@@ -50,22 +50,22 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/dog_safe.jpg')"><img src="<%= slug %>/public/images/dog_safe.jpg"></a>
+								<a onclick="getInfo('<%= slug %>/public/images/dog_safe.jpg')"><img src="<%= slug %>/public/images/dog_safe.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/yosemite_safe.jpg')"><img src="<%= slug %>/public/images/yosemite_safe.jpg"></a>
+								<a onclick="getInfo('<%= slug %>/public/images/yosemite_safe.jpg')"><img src="<%= slug %>/public/images/yosemite_safe.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/obama_safe.jpg')"><img src="<%= slug %>/public/images/obama_safe.jpg"></a>
+								<a onclick="getInfo('<%= slug %>/public/images/obama_safe.jpg')"><img src="<%= slug %>/public/images/obama_safe.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/train_safe.jpg')"><img src="<%= slug %>/public/images/train_safe.jpg"></a>
+								<a onclick="getInfo('<%= slug %>/public/images/train_safe.jpg')"><img src="<%= slug %>/public/images/train_safe.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/mini_safe.jpg')"><img src="<%= slug %>/public/images/mini_safe.jpg"></a>
+								<a onclick="getInfo('<%= slug %>/public/images/mini_safe.jpg')"><img src="<%= slug %>/public/images/mini_safe.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('https://demos.algorithmia.com/image-tagger/public/images/teddy_safe.jpg')"><img src="<%= slug %>/public/images/teddy_safe.jpg"></a>
+								<a onclick="getInfo('<%= slug %>/public/images/teddy_safe.jpg')"><img src="<%= slug %>/public/images/teddy_safe.jpg"></a>
 							</div>
 						</div>
 					</div>

--- a/JavaScript/image-tagger/public/js/main.js
+++ b/JavaScript/image-tagger/public/js/main.js
@@ -21,7 +21,9 @@ $(document).ready(function() {
  */
 var getInfo = function(url) {
   if(url) {
-    $('#imgUrl').val(url.indexOf('http')==0?url:''); //only display http URLs
+    $('#imgUrl').val(
+      url.startsWith('http') ? url : `${window.location.origin}/${url}`
+    )
   } else {
     url = $('#imgUrl').val();
   }

--- a/JavaScript/places-demo/index.html
+++ b/JavaScript/places-demo/index.html
@@ -50,19 +50,19 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/alley.jpg')"><img src="<%= slug %>/public/images/alley.jpg"></a>
+								<a onclick="getPlaces('<%= slug %>/public/images/alley.jpg')"><img src="<%= slug %>/public/images/alley.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/airplane.jpg')"><img src="<%= slug %>/public/images/airplane.jpg"></a>
+								<a onclick="getPlaces('<%= slug %>/public/images/airplane.jpg')"><img src="<%= slug %>/public/images/airplane.jpg"></a>
 							</div> 
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/sunset.jpg')"><img src="<%= slug %>/public/images/sunset.jpg"></a>
+								<a onclick="getPlaces('<%= slug %>/public/images/sunset.jpg')"><img src="<%= slug %>/public/images/sunset.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/utah.jpg')"><img src="<%= slug %>/public/images/utah.jpg"></a>
+								<a onclick="getPlaces('<%= slug %>/public/images/utah.jpg')"><img src="<%= slug %>/public/images/utah.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('https://s3.amazonaws.com/algorithmia-assets/classifyplaces_static_content/market.jpg')"><img src="<%= slug %>/public/images/market.jpg"></a>
+								<a onclick="getPlaces('<%= slug %>/public/images/market.jpg')"><img src="<%= slug %>/public/images/market.jpg"></a>
 							</div>
 						</div>
 					</div>

--- a/JavaScript/places-demo/public/js/main.js
+++ b/JavaScript/places-demo/public/js/main.js
@@ -20,7 +20,9 @@ $(document).ready(function() {
  */
 var getPlaces = function(url) {
   if(url) {
-    $('#imgUrl').val(url.indexOf('http')==0?url:''); //only display http URLs
+    $('#imgUrl').val(
+      url.startsWith('http') ? url : `${window.location.origin}/${url}`
+
   } else {
     url = $('#imgUrl').val();
   }


### PR DESCRIPTION
Noticed while working on a new ticket that the URLs used by the onclick handlers don't necessarily match the URLs used for rendering images. This just goes through all the PRs you've already seen and ensures they're all referring to the same images.

I've updated the CloudFront origin for demos.test.algorithmia.com so that it points to the test demos website (it was prod before), so `location.origin` will actually work now.

https://demos.test.algorithmia.com/image-tagger
https://demos.test.algorithmia.com/deep-fashion
https://demos.test.algorithmia.com/classify-places
