### PR TITLE
Ensure correct error handler is called

### DIFF
--- a/JavaScript/deep-fashion/public/js/main.js
+++ b/JavaScript/deep-fashion/public/js/main.js
@@ -34,10 +34,10 @@ var getTags = function(url) {
   $('#userImg').attr('src',url);
   algoClient1.algo(algorithms.tagger).pipe(input).then(function (output) {
     if (output.error) {
-      endWait(output.error.message);
+      hideWait(output.error.message);
     } else {
       showPredictions(output.result.articles);
-      endWait();
+      hideWait();
     }
   });
 };
@@ -126,7 +126,7 @@ var initDropzone = function() {
   });
   dropzone.on("error", function(file, err) {
     dropzone.removeFile(file);
-    endWait(err);
+    hideWait(err);
   });
 };
 

--- a/JavaScript/places-demo/public/js/main.js
+++ b/JavaScript/places-demo/public/js/main.js
@@ -36,10 +36,10 @@ var getPlaces = function(url) {
   $('#userImg').attr('src',url);
   algoClient.algo(algorithms.tagger).pipe(input).then(function (output) {
     if (output.error) {
-      endWait(output.error.message);
+      hideWait(output.error.message);
     } else {
       showPredictions(output.result.predictions);
-      endWait();
+      hideWait();
     }
   });
 };
@@ -116,6 +116,6 @@ var initDropzone = function() {
   });
   dropzone.on("error", function(file, err) {
     dropzone.removeFile(file);
-    endWait(err);
+    hideWait(err);
   });
 };

--- a/JavaScript/video-search/public/js/main.js
+++ b/JavaScript/video-search/public/js/main.js
@@ -40,7 +40,7 @@ var search = function(query) {
       // Render search results
       try {
         renderSearchResults(query, output.result);
-        endWait(true);
+        hideWait(true);
       } catch(e) {
         console.log("error rendering", e);
         showError(e.message)
@@ -123,7 +123,7 @@ var showWait = function() {
  * hide dots, reveal button, enable links
  * @param showResults should the results section be revealed?
  */
-var endWait = function(showResults) {
+var hideWait = function(showResults) {
   $('#overlay').addClass('hidden');
   $("#analyze-button-text").removeClass("no-viz");
   $('#search-query').removeAttr('disabled');
@@ -142,5 +142,5 @@ var endWait = function(showResults) {
 
 var showError = function(message) {
   $("#status-label").html('<div class="alert alert-danger" role="alert">'+message+' </div>');
-  endWait(false);
+  hideWait(false);
 };

--- a/JavaScript/web-page-inspector/public/js/main.js
+++ b/JavaScript/web-page-inspector/public/js/main.js
@@ -28,7 +28,7 @@ var analyzeUrl = function(url) {
       if (output.error) {
         console.log("There was an error", output.error.message);
         $("#status-label").html('<div class="alert alert-danger" role="alert">' + output.error.message + ' </div>');
-        endWait();
+        hideWait();
       } else {
         // Add results to page
         showResults(output.result);
@@ -37,7 +37,7 @@ var analyzeUrl = function(url) {
   } else {
     // Error Handling
     $("#status-label").html('<div class="alert alert-danger" role="alert">Please enter a valid URL.</div>');
-    endWait();
+    hideWait();
   }
 };
 
@@ -137,7 +137,7 @@ var showResults = function(data){
   }
 
   // reveal and smooth-scroll to results section
-  endWait(true);
+  hideWait(true);
 
 };
 
@@ -183,7 +183,7 @@ var showWait = function() {
  * hide overlay & dots, reveal button
  * @param showResults should the results section be revealed?
  */
-var endWait = function(showResults) {
+var hideWait = function(showResults) {
   $("#overlay").addClass("hidden");
   $("#analyze-button-text").removeClass("no-viz");
   $(".dots-container").addClass("hidden");


### PR DESCRIPTION
Noticed while debugging the DNS issue that errors weren't being handled properly on some pages. Lots of pages had a `hideWait` function defined but called `endWait` instead. This ensures all functions across all demos use `endWait`.