### PR TITLE
Ensure DNS error doesnt occur when running demo algos

### DIFF
--- a/JavaScript/deep-fashion/index.html
+++ b/JavaScript/deep-fashion/index.html
@@ -50,19 +50,19 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('<%= slug %>/public/images/blouse.jpg')"><img src="<%= slug %>/public/images/blouse.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/blouse.jpg')"><img src="<%= slug %>/public/images/blouse.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('<%= slug %>/public/images/suit.jpg')"><img src="<%= slug %>/public/images/suit.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/suit.jpg')"><img src="<%= slug %>/public/images/suit.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('<%= slug %>/public/images/tights.jpg')"><img src="<%= slug %>/public/images/tights.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/tights.jpg')"><img src="<%= slug %>/public/images/tights.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('<%= slug %>/public/images/buttondown.jpg')"><img src="<%= slug %>/public/images/buttondown.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/buttondown.jpg')"><img src="<%= slug %>/public/images/buttondown.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getTags('<%= slug %>/public/images/blazer.jpg')"><img src="<%= slug %>/public/images/blazer.jpg"></a>
+								<a onclick="getTags('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/blazer.jpg')"><img src="<%= slug %>/public/images/blazer.jpg"></a>
 							</div>
 						</div>
 					</div>

--- a/JavaScript/deep-filter/index.html
+++ b/JavaScript/deep-filter/index.html
@@ -109,16 +109,16 @@
 						<h4 class="has-subcontent">Or, filter a sample image</h4>
 						<div class="row">
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center sample-image">
-								<a onclick="analyzeDefault('<%= slug %>/public/images/beetle.jpg')"><img src="<%= slug %>/public/images/beetle.jpg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/beetle.jpg')"><img src="<%= slug %>/public/images/beetle.jpg" class="sample-img"></a>
 							</div>
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center sample-image">
-								<a onclick="analyzeDefault('<%= slug %>/public/images/castle.jpg')"><img src="<%= slug %>/public/images/castle.jpg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/castle.jpg')"><img src="<%= slug %>/public/images/castle.jpg" class="sample-img"></a>
 							</div>
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center sample-image">
-								<a onclick="analyzeDefault('<%= slug %>/public/images/face.jpg')"><img src="<%= slug %>/public/images/face.jpg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/face.jpg')"><img src="<%= slug %>/public/images/face.jpg" class="sample-img"></a>
 							</div>
 							<div class="col-xs-6 col-sm-3 col-md-3 sample-center sample-image">
-								<a onclick="analyzeDefault('<%= slug %>/public/images/lioness.jpg')"><img src="<%= slug %>/public/images/lioness.jpg" class="sample-img"></a>
+								<a onclick="analyzeDefault('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/lioness.jpg')"><img src="<%= slug %>/public/images/lioness.jpg" class="sample-img"></a>
 							</div>
 						</div>
 					</div>

--- a/JavaScript/image-tagger/index.html
+++ b/JavaScript/image-tagger/index.html
@@ -50,22 +50,22 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('<%= slug %>/public/images/dog_safe.jpg')"><img src="<%= slug %>/public/images/dog_safe.jpg"></a>
+								<a onclick="getInfo('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/dog_safe.jpg')"><img src="<%= slug %>/public/images/dog_safe.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('<%= slug %>/public/images/yosemite_safe.jpg')"><img src="<%= slug %>/public/images/yosemite_safe.jpg"></a>
+								<a onclick="getInfo('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/yosemite_safe.jpg')"><img src="<%= slug %>/public/images/yosemite_safe.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('<%= slug %>/public/images/obama_safe.jpg')"><img src="<%= slug %>/public/images/obama_safe.jpg"></a>
+								<a onclick="getInfo('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/obama_safe.jpg')"><img src="<%= slug %>/public/images/obama_safe.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('<%= slug %>/public/images/train_safe.jpg')"><img src="<%= slug %>/public/images/train_safe.jpg"></a>
+								<a onclick="getInfo('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/train_safe.jpg')"><img src="<%= slug %>/public/images/train_safe.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('<%= slug %>/public/images/mini_safe.jpg')"><img src="<%= slug %>/public/images/mini_safe.jpg"></a>
+								<a onclick="getInfo('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/mini_safe.jpg')"><img src="<%= slug %>/public/images/mini_safe.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getInfo('<%= slug %>/public/images/teddy_safe.jpg')"><img src="<%= slug %>/public/images/teddy_safe.jpg"></a>
+								<a onclick="getInfo('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/teddy_safe.jpg')"><img src="<%= slug %>/public/images/teddy_safe.jpg"></a>
 							</div>
 						</div>
 					</div>

--- a/JavaScript/places-demo/index.html
+++ b/JavaScript/places-demo/index.html
@@ -50,19 +50,19 @@
 						<h4 class="dark whitespace-sm">Or, try these sample images:</h4>
 						<div class="row whitespace-none sample-images">
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('<%= slug %>/public/images/alley.jpg')"><img src="<%= slug %>/public/images/alley.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/alley.jpg')"><img src="<%= slug %>/public/images/alley.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('<%= slug %>/public/images/airplane.jpg')"><img src="<%= slug %>/public/images/airplane.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/airplane.jpg')"><img src="<%= slug %>/public/images/airplane.jpg"></a>
 							</div> 
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('<%= slug %>/public/images/sunset.jpg')"><img src="<%= slug %>/public/images/sunset.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/sunset.jpg')"><img src="<%= slug %>/public/images/sunset.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('<%= slug %>/public/images/utah.jpg')"><img src="<%= slug %>/public/images/utah.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/utah.jpg')"><img src="<%= slug %>/public/images/utah.jpg"></a>
 							</div>
 							<div class="col-xs-4 col-sm-2 sample-image">
-								<a onclick="getPlaces('<%= slug %>/public/images/market.jpg')"><img src="<%= slug %>/public/images/market.jpg"></a>
+								<a onclick="getPlaces('https://s3.amazonaws.com/demos.algorithmia.com/<%= slug %>/public/images/market.jpg')"><img src="<%= slug %>/public/images/market.jpg"></a>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
Earlier this last sprint before deploying these, I noticed that the new images wouldn't work properly when using any of the demos. (The API would return an error and the loading state would persist.)

Turns out that we can't use the host `(test.)?algorithmnia.com` for the same reason `(test.)?algorithmia.com` doesn't work when we're on the VPN: the DNS records are different inside and outside our cluster. When the algo attempts to fetch the image, it can't resolve the DNS name properly so it throws an error. I've updated all URLs to use the S3 URL instead of the CloudFront URL and it works fine now.